### PR TITLE
Switch the entire codebase over to the rtkwlf namespace

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,7 +18,7 @@ changelog:
   skip: true
 release:
   github:
-    owner: jrbeverly
+    owner: rtkwlf
     name: bmx
   prerelease: auto
   name_template: "v{{.Version}}"

--- a/BUILD
+++ b/BUILD
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test", "nogo")
 load("@bazel_gazelle//:def.bzl", "gazelle")
 
-# gazelle:prefix github.com/jrbeverly/bmx
+# gazelle:prefix github.com/rtkwlf/bmx
 gazelle(name = "gazelle")
 
 go_library(
@@ -14,7 +14,7 @@ go_library(
         "print_windows.go",
         "write.go",
     ],
-    importpath = "github.com/jrbeverly/bmx",
+    importpath = "github.com/rtkwlf/bmx",
     visibility = ["//visibility:public"],
     deps = [
         "//console:go_default_library",

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ BMX prints detailed usage information when you run `bmx -h` or `bmx <cmd> -h`.
 
 ## Installation
 
-Available versions of BMX are available on the [releases](https://github.com/jrbeverly/bmx/releases) page. 
+Available versions of BMX are available on the [releases](https://github.com/rtkwlf/bmx/releases) page. 
 
 ## Features
 
@@ -57,13 +57,13 @@ BMX is designed to be extensible and easily rolled out.
 ### Developer Setup
 
 ```sh
-go get github.com/jrbeverly/bmx
+go get github.com/rtkwlf/bmx
 ```
 
 ### Building
 
 ```bash
-go build github.com/jrbeverly/bmx/cmd/bmx
+go build github.com/rtkwlf/bmx/cmd/bmx
 
 bazel build --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //cmd/bmx:bmx
 bazel build --platforms=@io_bazel_rules_go//go/toolchain:windows_amd64 //cmd/bmx:bmx
@@ -72,7 +72,7 @@ bazel build --platforms=@io_bazel_rules_go//go/toolchain:darwin_amd64 //cmd/bmx:
 
 ### Getting Involved
 
-BMX has [issues](https://github.com/jrbeverly/bmx/issues).
+BMX has [issues](https://github.com/rtkwlf/bmx/issues).
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 

--- a/cmd/bmx/BUILD.bazel
+++ b/cmd/bmx/BUILD.bazel
@@ -9,7 +9,7 @@ go_library(
         "version.go",
         "write.go",
     ],
-    importpath = "github.com/jrbeverly/bmx/cmd/bmx",
+    importpath = "github.com/rtkwlf/bmx/cmd/bmx",
     visibility = ["//visibility:public"],
     deps = [
         "//:go_default_library",

--- a/cmd/bmx/bmx.go
+++ b/cmd/bmx/bmx.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/jrbeverly/bmx/config"
-	"github.com/jrbeverly/bmx/console"
+	"github.com/rtkwlf/bmx/config"
+	"github.com/rtkwlf/bmx/console"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/bmx/credential-process.go
+++ b/cmd/bmx/credential-process.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/jrbeverly/bmx/config"
+	"github.com/rtkwlf/bmx/config"
 
-	"github.com/jrbeverly/bmx/saml/identityProviders/okta"
-	"github.com/jrbeverly/bmx/saml/serviceProviders/aws"
+	"github.com/rtkwlf/bmx/saml/identityProviders/okta"
+	"github.com/rtkwlf/bmx/saml/serviceProviders/aws"
 
-	"github.com/jrbeverly/bmx"
+	"github.com/rtkwlf/bmx"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/bmx/print.go
+++ b/cmd/bmx/print.go
@@ -20,12 +20,12 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/jrbeverly/bmx/config"
+	"github.com/rtkwlf/bmx/config"
 
-	"github.com/jrbeverly/bmx/saml/identityProviders/okta"
-	"github.com/jrbeverly/bmx/saml/serviceProviders/aws"
+	"github.com/rtkwlf/bmx/saml/identityProviders/okta"
+	"github.com/rtkwlf/bmx/saml/serviceProviders/aws"
 
-	"github.com/jrbeverly/bmx"
+	"github.com/rtkwlf/bmx"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/bmx/write.go
+++ b/cmd/bmx/write.go
@@ -19,11 +19,11 @@ package main
 import (
 	"log"
 
-	"github.com/jrbeverly/bmx/config"
-	"github.com/jrbeverly/bmx/saml/identityProviders/okta"
-	"github.com/jrbeverly/bmx/saml/serviceProviders/aws"
+	"github.com/rtkwlf/bmx/config"
+	"github.com/rtkwlf/bmx/saml/identityProviders/okta"
+	"github.com/rtkwlf/bmx/saml/serviceProviders/aws"
 
-	"github.com/jrbeverly/bmx"
+	"github.com/rtkwlf/bmx"
 	"github.com/spf13/cobra"
 )
 

--- a/config/BUILD.bazel
+++ b/config/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["loadConfig.go"],
-    importpath = "github.com/jrbeverly/bmx/config",
+    importpath = "github.com/rtkwlf/bmx/config",
     visibility = ["//visibility:public"],
     deps = [
         "@com_github_mitchellh_go_homedir//:go_default_library",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/jrbeverly/bmx/config"
+	"github.com/rtkwlf/bmx/config"
 	"github.com/magiconair/properties/assert"
 )
 

--- a/console.go
+++ b/console.go
@@ -21,10 +21,10 @@ import (
 	"log"
 	"strings"
 
-	"github.com/jrbeverly/bmx/console"
-	"github.com/jrbeverly/bmx/saml/identityProviders"
-	"github.com/jrbeverly/bmx/saml/identityProviders/okta"
-	"github.com/jrbeverly/bmx/saml/serviceProviders"
+	"github.com/rtkwlf/bmx/console"
+	"github.com/rtkwlf/bmx/saml/identityProviders"
+	"github.com/rtkwlf/bmx/saml/identityProviders/okta"
+	"github.com/rtkwlf/bmx/saml/serviceProviders"
 )
 
 const (

--- a/console/BUILD.bazel
+++ b/console/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["ConsoleReader.go"],
-    importpath = "github.com/jrbeverly/bmx/console",
+    importpath = "github.com/rtkwlf/bmx/console",
     visibility = ["//visibility:public"],
     deps = ["@org_golang_x_crypto//ssh/terminal:go_default_library"],
 )

--- a/credential-process.go
+++ b/credential-process.go
@@ -5,11 +5,11 @@ import (
 	"log"
 	"time"
 
-	"github.com/jrbeverly/bmx/console"
-	"github.com/jrbeverly/bmx/saml/identityProviders"
+	"github.com/rtkwlf/bmx/console"
+	"github.com/rtkwlf/bmx/saml/identityProviders"
 
 	"github.com/aws/aws-sdk-go/service/sts"
-	"github.com/jrbeverly/bmx/saml/serviceProviders"
+	"github.com/rtkwlf/bmx/saml/serviceProviders"
 )
 
 type CredentialProcessCmdOptions struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jrbeverly/bmx
+module github.com/rtkwlf/bmx
 
 go 1.14
 

--- a/mocks/BUILD.bazel
+++ b/mocks/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
         "consoleReader.go",
         "mokta.go",
     ],
-    importpath = "github.com/jrbeverly/bmx/mocks",
+    importpath = "github.com/rtkwlf/bmx/mocks",
     visibility = ["//visibility:public"],
     deps = ["//saml/identityProviders/okta:go_default_library"],
 )

--- a/mocks/mokta.go
+++ b/mocks/mokta.go
@@ -19,7 +19,7 @@ package mocks
 import (
 	"net/url"
 
-	"github.com/jrbeverly/bmx/saml/identityProviders/okta"
+	"github.com/rtkwlf/bmx/saml/identityProviders/okta"
 )
 
 type Mokta struct {

--- a/print.go
+++ b/print.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/jrbeverly/bmx/console"
-	"github.com/jrbeverly/bmx/saml/identityProviders"
+	"github.com/rtkwlf/bmx/console"
+	"github.com/rtkwlf/bmx/saml/identityProviders"
 
 	"github.com/aws/aws-sdk-go/service/sts"
-	"github.com/jrbeverly/bmx/saml/serviceProviders"
+	"github.com/rtkwlf/bmx/saml/serviceProviders"
 )
 
 const (

--- a/print_test.go
+++ b/print_test.go
@@ -20,9 +20,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/jrbeverly/bmx"
-	"github.com/jrbeverly/bmx/mocks"
-	awsmocks "github.com/jrbeverly/bmx/saml/serviceProviders/aws/mocks"
+	"github.com/rtkwlf/bmx"
+	"github.com/rtkwlf/bmx/mocks"
+	awsmocks "github.com/rtkwlf/bmx/saml/serviceProviders/aws/mocks"
 )
 
 func assertAwsTokenEnv(t *testing.T, output string) {

--- a/saml/identityProviders/BUILD.bazel
+++ b/saml/identityProviders/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["IdentityProvider.go"],
-    importpath = "github.com/jrbeverly/bmx/saml/identityProviders",
+    importpath = "github.com/rtkwlf/bmx/saml/identityProviders",
     visibility = ["//visibility:public"],
     deps = ["//saml/identityProviders/okta:go_default_library"],
 )

--- a/saml/identityProviders/IdentityProvider.go
+++ b/saml/identityProviders/IdentityProvider.go
@@ -17,7 +17,7 @@ limitations under the License.
 package identityProviders
 
 import (
-	"github.com/jrbeverly/bmx/saml/identityProviders/okta"
+	"github.com/rtkwlf/bmx/saml/identityProviders/okta"
 )
 
 type IdentityProvider interface {

--- a/saml/identityProviders/okta/BUILD.bazel
+++ b/saml/identityProviders/okta/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["okta.go"],
-    importpath = "github.com/jrbeverly/bmx/saml/identityProviders/okta",
+    importpath = "github.com/rtkwlf/bmx/saml/identityProviders/okta",
     visibility = ["//visibility:public"],
     deps = [
         "//console:go_default_library",

--- a/saml/identityProviders/okta/file/BUILD.bazel
+++ b/saml/identityProviders/okta/file/BUILD.bazel
@@ -3,6 +3,6 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["oktaSession.go"],
-    importpath = "github.com/jrbeverly/bmx/saml/identityProviders/okta/file",
+    importpath = "github.com/rtkwlf/bmx/saml/identityProviders/okta/file",
     visibility = ["//visibility:public"],
 )

--- a/saml/identityProviders/okta/mocks/BUILD.bazel
+++ b/saml/identityProviders/okta/mocks/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["mocks.go"],
-    importpath = "github.com/jrbeverly/bmx/saml/identityProviders/okta/mocks",
+    importpath = "github.com/rtkwlf/bmx/saml/identityProviders/okta/mocks",
     visibility = ["//visibility:public"],
     deps = ["//saml/identityProviders/okta/file:go_default_library"],
 )

--- a/saml/identityProviders/okta/mocks/mocks.go
+++ b/saml/identityProviders/okta/mocks/mocks.go
@@ -17,7 +17,7 @@ limitations under the License.
 package mocks
 
 import (
-	"github.com/jrbeverly/bmx/saml/identityProviders/okta/file"
+	"github.com/rtkwlf/bmx/saml/identityProviders/okta/file"
 )
 
 type SessionCache struct {

--- a/saml/identityProviders/okta/okta.go
+++ b/saml/identityProviders/okta/okta.go
@@ -29,8 +29,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jrbeverly/bmx/console"
-	"github.com/jrbeverly/bmx/saml/identityProviders/okta/file"
+	"github.com/rtkwlf/bmx/console"
+	"github.com/rtkwlf/bmx/saml/identityProviders/okta/file"
 	"golang.org/x/net/html"
 	"golang.org/x/net/publicsuffix"
 )

--- a/saml/identityProviders/okta/okta_test.go
+++ b/saml/identityProviders/okta/okta_test.go
@@ -24,10 +24,10 @@ import (
 	"testing"
 	"time"
 
-	globalmocks "github.com/jrbeverly/bmx/mocks"
-	"github.com/jrbeverly/bmx/saml/identityProviders/okta"
-	"github.com/jrbeverly/bmx/saml/identityProviders/okta/file"
-	"github.com/jrbeverly/bmx/saml/identityProviders/okta/mocks"
+	globalmocks "github.com/rtkwlf/bmx/mocks"
+	"github.com/rtkwlf/bmx/saml/identityProviders/okta"
+	"github.com/rtkwlf/bmx/saml/identityProviders/okta/file"
+	"github.com/rtkwlf/bmx/saml/identityProviders/okta/mocks"
 )
 
 var (

--- a/saml/serviceProviders/BUILD.bazel
+++ b/saml/serviceProviders/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
         "UserInfo.go",
         "serviceProvider.go",
     ],
-    importpath = "github.com/jrbeverly/bmx/saml/serviceProviders",
+    importpath = "github.com/rtkwlf/bmx/saml/serviceProviders",
     visibility = ["//visibility:public"],
     deps = ["@com_github_aws_aws_sdk_go//service/sts:go_default_library"],
 )

--- a/saml/serviceProviders/aws/BUILD.bazel
+++ b/saml/serviceProviders/aws/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["provider.go"],
-    importpath = "github.com/jrbeverly/bmx/saml/serviceProviders/aws",
+    importpath = "github.com/rtkwlf/bmx/saml/serviceProviders/aws",
     visibility = ["//visibility:public"],
     deps = [
         "//console:go_default_library",

--- a/saml/serviceProviders/aws/mocks/BUILD.bazel
+++ b/saml/serviceProviders/aws/mocks/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["awsServiceProvider.go"],
-    importpath = "github.com/jrbeverly/bmx/saml/serviceProviders/aws/mocks",
+    importpath = "github.com/rtkwlf/bmx/saml/serviceProviders/aws/mocks",
     visibility = ["//visibility:public"],
     deps = [
         "@com_github_aws_aws_sdk_go//aws:go_default_library",

--- a/saml/serviceProviders/aws/provider.go
+++ b/saml/serviceProviders/aws/provider.go
@@ -24,7 +24,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/jrbeverly/bmx/console"
+	"github.com/rtkwlf/bmx/console"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"

--- a/saml/serviceProviders/aws/provider_test.go
+++ b/saml/serviceProviders/aws/provider_test.go
@@ -20,14 +20,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jrbeverly/bmx/mocks"
+	"github.com/rtkwlf/bmx/mocks"
 
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
 
 	"github.com/aws/aws-sdk-go/aws"
 
 	"github.com/aws/aws-sdk-go/service/sts"
-	awsService "github.com/jrbeverly/bmx/saml/serviceProviders/aws"
+	awsService "github.com/rtkwlf/bmx/saml/serviceProviders/aws"
 )
 
 type stsMock struct {

--- a/write.go
+++ b/write.go
@@ -22,9 +22,9 @@ import (
 	"runtime"
 
 	"github.com/aws/aws-sdk-go/service/sts"
-	"github.com/jrbeverly/bmx/console"
-	"github.com/jrbeverly/bmx/saml/identityProviders"
-	"github.com/jrbeverly/bmx/saml/serviceProviders"
+	"github.com/rtkwlf/bmx/console"
+	"github.com/rtkwlf/bmx/saml/identityProviders"
+	"github.com/rtkwlf/bmx/saml/serviceProviders"
 	"gopkg.in/ini.v1"
 )
 


### PR DESCRIPTION
Switch the namespace from `jrbeverly/bmx` to `rtkwlf/bmx`.

The adjustments were done against the repository `jrbeverly/bmx`, as it already had working github-actions and was configured in a working manner. While experimenting this was fine, but now that the project is under the `rtkwlf` organization, it makes more sense to gather it under that.

This changes from the namespace using `jrbeverly/bmx`, to using `rtkwlf/bmx` as the target.