### PR TITLE
chore(spelling): Resolve spelling error in the aws string mocks

### DIFF
--- a/saml/serviceProviders/aws/mocks/awsServiceProvider.go
+++ b/saml/serviceProviders/aws/mocks/awsServiceProvider.go
@@ -28,7 +28,7 @@ type AwsServiceProviderMock struct{}
 func (a AwsServiceProviderMock) GetCredentials(saml string, desiredRole string) *sts.Credentials {
 	return &sts.Credentials{
 		AccessKeyId:     aws.String("access_key_id"),
-		SecretAccessKey: aws.String("secrest_access_key"),
+		SecretAccessKey: aws.String("secret_access_key"),
 		SessionToken:    aws.String("session_token"),
 		Expiration:      aws.Time(time.Now().Add(time.Hour * 8)),
 	}

--- a/saml/serviceProviders/aws/provider_test.go
+++ b/saml/serviceProviders/aws/provider_test.go
@@ -38,7 +38,7 @@ func (s *stsMock) AssumeRoleWithSAML(input *sts.AssumeRoleWithSAMLInput) (*sts.A
 	out := &sts.AssumeRoleWithSAMLOutput{
 		Credentials: &sts.Credentials{
 			AccessKeyId:     aws.String("access_key_id"),
-			SecretAccessKey: aws.String("secrest_access_key"),
+			SecretAccessKey: aws.String("secret_access_key"),
 			SessionToken:    aws.String("session_token"),
 			Expiration:      aws.Time(time.Now().Add(time.Hour * 8)),
 		},


### PR DESCRIPTION
Resolve a spelling mistake in the `SecretAccessKey` AWS mocks.