### PR TITLE
fix(ineffassign): Ineffectual assignments of err responses in okta provider

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -23,8 +23,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/rtkwlf/bmx/config"
 	"github.com/magiconair/properties/assert"
+	"github.com/rtkwlf/bmx/config"
 )
 
 func TestLoadConfigFile(t *testing.T) {
@@ -47,6 +47,9 @@ func TestLoadConfigFile(t *testing.T) {
 	}
 
 	err = os.MkdirAll(path.Join(tempUserDir, ".bmx"), os.ModeDir|os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
 	userConfigFile := filepath.ToSlash(path.Join(tempUserDir, ".bmx", "config"))
 	ioutil.WriteFile(userConfigFile, []byte("allow_project_configs=true"), os.ModePerm)
 

--- a/saml/identityProviders/okta/okta.go
+++ b/saml/identityProviders/okta/okta.go
@@ -119,6 +119,9 @@ func (o *OktaClient) Authenticate(username, password, org string) (string, error
 
 	oktaAuthResponse := &OktaAuthResponse{}
 	z, err := ioutil.ReadAll(authResponse.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
 	err = json.Unmarshal(z, &oktaAuthResponse)
 	if err != nil {
 		log.Fatal(err)
@@ -147,12 +150,18 @@ func (o *OktaClient) AuthenticateFromCache(username, org string) (string, bool) 
 	url := o.BaseUrl.ResolveReference(rel)
 
 	meRequest, err := http.NewRequest("GET", url.String(), nil)
+	if err != nil {
+		return "", false
+	}
 	meResponse, err := o.HttpClient.Do(meRequest)
 	if err != nil {
 		return "", false
 	}
 	var me OktaMeResponse
 	b, err := ioutil.ReadAll(meResponse.Body)
+	if err != nil {
+		return "", false
+	}
 	err = json.Unmarshal(b, &me)
 	if err != nil {
 		return "", false
@@ -165,12 +174,18 @@ func (o *OktaClient) ListApplications(userId string) ([]OktaAppLink, error) {
 	url := o.BaseUrl.ResolveReference(rel)
 
 	listApplicationRequest, err := http.NewRequest("GET", url.String(), nil)
+	if err != nil {
+		return nil, err
+	}
 	listApplicationsResponse, err := o.HttpClient.Do(listApplicationRequest)
 	if err != nil {
 		return nil, err
 	}
 	var oktaApplications []OktaAppLink
 	b, err := ioutil.ReadAll(listApplicationsResponse.Body)
+	if err != nil {
+		return nil, err
+	}
 	err = json.Unmarshal(b, &oktaApplications)
 	if err != nil {
 		return nil, err
@@ -192,10 +207,19 @@ func (o *OktaClient) startSession(sessionToken string) (*OktaSessionResponse, er
 		SessionToken: sessionToken,
 	}
 	b, err := json.Marshal(oktaSessionsRequest)
+	if err != nil {
+		return nil, err
+	}
 	sessionResponse, err := o.HttpClient.Post(url.String(), applicationJson, bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
 
 	oktaSessionResponse := &OktaSessionResponse{}
 	b, err = ioutil.ReadAll(sessionResponse.Body)
+	if err != nil {
+		return nil, err
+	}
 	err = json.Unmarshal(b, oktaSessionResponse)
 	if err != nil {
 		return nil, err

--- a/saml/identityProviders/okta/okta_test.go
+++ b/saml/identityProviders/okta/okta_test.go
@@ -71,7 +71,7 @@ func TestAuthenticateFromCacheWithExistingSession(t *testing.T) {
 	defer closeServer()
 
 	sessions := []file.OktaSessionCache{
-		file.OktaSessionCache{
+		{
 			Userid:    "blah",
 			Org:       "org",
 			SessionId: "Id",
@@ -96,7 +96,7 @@ func TestAuthenticateFromCacheWithExpiredExistingSession(t *testing.T) {
 	defer closeServer()
 
 	sessions := []file.OktaSessionCache{
-		file.OktaSessionCache{
+		{
 			Userid:    "blah",
 			Org:       "org",
 			SessionId: "Id",


### PR DESCRIPTION
Resolve a series of ineffectual error assignments in the Okta provider.

This was caught by goreportcard-cli, when run against the project. The style of err handling is mirrored by similar if statements in the area.

Catching these errors will need to be bundled into CI at a later date to prevent them from occurring in the future.