### PR TITLE
feat(version): Stamp compiled binary with version and commit

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+build --stamp --workspace_status_command=./tools/stamp.sh

--- a/cmd/bmx/BUILD.bazel
+++ b/cmd/bmx/BUILD.bazel
@@ -25,4 +25,5 @@ go_binary(
     name = "bmx",
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
+    x_defs = {"version": "{STABLE_GIT_COMMIT}"},
 )

--- a/cmd/bmx/BUILD.bazel
+++ b/cmd/bmx/BUILD.bazel
@@ -25,5 +25,8 @@ go_binary(
     name = "bmx",
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
-    x_defs = {"version": "{STABLE_GIT_COMMIT}"},
+    x_defs = {
+        "version": "{BMX_VERSION}",
+        "commit": "{STABLE_GIT_COMMIT}",
+    },
 )

--- a/cmd/bmx/version.go
+++ b/cmd/bmx/version.go
@@ -27,12 +27,19 @@ var commit string
 
 func init() {
 	rootCmd.AddCommand(versionCmd)
+	if version == "" {
+		version = "nover"
+	}
 }
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print BMX version and exit",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("bmx/%s git/%s\n", version, commit)
+		if commit != "" {
+			fmt.Printf("bmx/%s git/%s\n", version, commit)
+		} else {
+			fmt.Println("bmx/nostamp")
+		}
 	},
 }

--- a/cmd/bmx/version.go
+++ b/cmd/bmx/version.go
@@ -16,9 +16,26 @@ limitations under the License.
 
 package main
 
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
 var version string
+var commit string
 
 func init() {
-	rootCmd.InitDefaultVersionFlag()
-	rootCmd.Version = version
+	rootCmd.AddCommand(versionCmd)
+	if version == "" {
+		rootCmd.Version = "dev"
+	}
+}
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print BMX version and exit",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("bmx/%s git/%s\n", rootCmd.Version, commit)
+	},
 }

--- a/cmd/bmx/version.go
+++ b/cmd/bmx/version.go
@@ -27,15 +27,12 @@ var commit string
 
 func init() {
 	rootCmd.AddCommand(versionCmd)
-	if version == "" {
-		rootCmd.Version = "dev"
-	}
 }
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print BMX version and exit",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("bmx/%s git/%s\n", rootCmd.Version, commit)
+		fmt.Printf("bmx/%s git/%s\n", version, commit)
 	},
 }

--- a/cmd/bmx/version.go
+++ b/cmd/bmx/version.go
@@ -16,22 +16,9 @@ limitations under the License.
 
 package main
 
-import (
-	"fmt"
-
-	"github.com/spf13/cobra"
-)
-
 var version string
 
 func init() {
-	rootCmd.AddCommand(versionCmd)
-}
-
-var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "Print BMX version and exit",
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("BMX version %s\n", version)
-	},
+	rootCmd.InitDefaultVersionFlag()
+	rootCmd.Version = version
 }

--- a/tools/stamp.sh
+++ b/tools/stamp.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo STABLE_GIT_COMMIT $(git rev-parse HEAD)

--- a/tools/stamp.sh
+++ b/tools/stamp.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
 echo STABLE_GIT_COMMIT $(git rev-parse HEAD)
+echo BMX_VERSION $(git tag --points-at HEAD | head -n 1)


### PR DESCRIPTION
Stamp the bazel compiled binaries (missing goreleaser binaries) with the version and commit sha.

For debugging purposes it will be good to have a commit sha associated with the binary, so it can referenced back if its an out of date version of `bmx`. For cases that are installed with `go get`, the version will not be stamped, which will yield the `bmx/nostamp` output. 