### PR TITLE
feat(cmd-login): Login command for creating Okta sessions

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -9,6 +9,7 @@ go_library(
     srcs = [
         "console.go",
         "credential-process.go",
+        "login.go",
         "print.go",
         "print_unix.go",
         "print_windows.go",

--- a/cmd/bmx/BUILD.bazel
+++ b/cmd/bmx/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "bmx.go",
         "credential-process.go",
+        "login.go",
         "print.go",
         "version.go",
         "write.go",

--- a/cmd/bmx/login.go
+++ b/cmd/bmx/login.go
@@ -7,7 +7,6 @@ import (
 	"github.com/rtkwlf/bmx/config"
 
 	"github.com/rtkwlf/bmx/saml/identityProviders/okta"
-	"github.com/rtkwlf/bmx/saml/serviceProviders/aws"
 
 	"github.com/rtkwlf/bmx"
 	"github.com/spf13/cobra"
@@ -35,16 +34,15 @@ var loginCmd = &cobra.Command{
 	Short: "Create a session",
 	Long:  `If logged out, create a new session`,
 	Run: func(cmd *cobra.Command, args []string) {
-		mergedOptions := mergePrintOptions(userConfig, loginOptions)
+		mergedOptions := mergeLoginOptions(userConfig, loginOptions)
 
 		oktaClient, err := okta.NewOktaClient(mergedOptions.Org, consolerw)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		awsProvider := aws.NewAwsServiceProvider(consolerw)
-		command := bmx.Print(oktaClient, awsProvider, consolerw, mergedOptions)
-		fmt.Println(command)
+		response := bmx.Login(oktaClient, consolerw, mergedOptions)
+		fmt.Println(response)
 	},
 }
 

--- a/cmd/bmx/login.go
+++ b/cmd/bmx/login.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/rtkwlf/bmx/config"
+
+	"github.com/rtkwlf/bmx/saml/identityProviders/okta"
+	"github.com/rtkwlf/bmx/saml/serviceProviders/aws"
+
+	"github.com/rtkwlf/bmx"
+	"github.com/spf13/cobra"
+)
+
+var loginOptions = bmx.LoginCmdOptions{}
+
+func init() {
+	loginCmd.Flags().StringVar(&loginOptions.Org, "org", "", "the okta org api to target")
+	loginCmd.Flags().StringVar(&loginOptions.User, "user", "", "the user to authenticate with")
+	loginCmd.Flags().StringVar(&loginOptions.Account, "account", "", "the account name to auth against")
+	loginCmd.Flags().StringVar(&loginOptions.Role, "role", "", "the desired role to assume")
+	loginCmd.Flags().BoolVar(&loginOptions.NoMask, "nomask", false, "set to not mask the password. this helps with debugging.")
+	loginCmd.Flags().StringVar(&loginOptions.Output, "output", "", "the output format [bash|powershell]")
+
+	if userConfig.Org == "" {
+		loginCmd.MarkFlagRequired("org")
+	}
+
+	rootCmd.AddCommand(loginCmd)
+}
+
+var loginCmd = &cobra.Command{
+	Use:   "login",
+	Short: "Create a session",
+	Long:  `If logged out, create a new session`,
+	Run: func(cmd *cobra.Command, args []string) {
+		mergedOptions := mergePrintOptions(userConfig, loginOptions)
+
+		oktaClient, err := okta.NewOktaClient(mergedOptions.Org, consolerw)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		awsProvider := aws.NewAwsServiceProvider(consolerw)
+		command := bmx.Print(oktaClient, awsProvider, consolerw, mergedOptions)
+		fmt.Println(command)
+	},
+}
+
+func mergeLoginOptions(uc config.UserConfig, pc bmx.LoginCmdOptions) bmx.LoginCmdOptions {
+	if pc.Org == "" {
+		pc.Org = uc.Org
+	}
+	if pc.User == "" {
+		pc.User = uc.User
+	}
+	if pc.Account == "" {
+		pc.Account = uc.Account
+	}
+	if pc.Role == "" {
+		pc.Role = uc.Role
+	}
+
+	return pc
+}

--- a/cmd/bmx/login.go
+++ b/cmd/bmx/login.go
@@ -20,7 +20,6 @@ func init() {
 	loginCmd.Flags().StringVar(&loginOptions.Account, "account", "", "the account name to auth against")
 	loginCmd.Flags().StringVar(&loginOptions.Role, "role", "", "the desired role to assume")
 	loginCmd.Flags().BoolVar(&loginOptions.NoMask, "nomask", false, "set to not mask the password. this helps with debugging.")
-	loginCmd.Flags().StringVar(&loginOptions.Output, "output", "", "the output format [bash|powershell]")
 
 	if userConfig.Org == "" {
 		loginCmd.MarkFlagRequired("org")

--- a/login.go
+++ b/login.go
@@ -1,11 +1,12 @@
 package bmx
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/rtkwlf/bmx/console"
-	"github.com/rtkwlf/bmx/saml/identityProviders"
 
+	"github.com/rtkwlf/bmx/saml/identityProviders/okta"
 	"github.com/rtkwlf/bmx/saml/serviceProviders"
 )
 
@@ -31,7 +32,7 @@ func GetUserInfoFromLoginCmdOptions(loginOptions LoginCmdOptions) serviceProvide
 	return user
 }
 
-func Login(idProvider identityProviders.IdentityProvider, consolerw console.ConsoleReader, loginOptions LoginCmdOptions) string {
+func Login(idProvider *okta.OktaClient, consolerw console.ConsoleReader, loginOptions LoginCmdOptions) string {
 	loginOptions.User = getUserIfEmpty(consolerw, loginOptions.User)
 	user := GetUserInfoFromLoginCmdOptions(loginOptions)
 
@@ -39,5 +40,10 @@ func Login(idProvider identityProviders.IdentityProvider, consolerw console.Cons
 	if err != nil {
 		log.Fatal(err)
 	}
-	return "Session created."
+
+	session, ok := idProvider.GetCachedOktaSession(loginOptions.User, loginOptions.Org)
+	if !ok {
+		return fmt.Sprintf("Failed to create session for %s", loginOptions.User)
+	}
+	return fmt.Sprintf("Session for %s expires at %s", session.Userid, session.ExpiresAt)
 }

--- a/login.go
+++ b/login.go
@@ -18,7 +18,6 @@ type LoginCmdOptions struct {
 	NoMask   bool
 	Password string
 	Role     string
-	Output   string
 }
 
 func GetUserInfoFromLoginCmdOptions(loginOptions LoginCmdOptions) serviceProviders.UserInfo {

--- a/login.go
+++ b/login.go
@@ -1,0 +1,43 @@
+package bmx
+
+import (
+	"log"
+
+	"github.com/rtkwlf/bmx/console"
+	"github.com/rtkwlf/bmx/saml/identityProviders"
+
+	"github.com/rtkwlf/bmx/saml/serviceProviders"
+)
+
+type LoginCmdOptions struct {
+	Org      string
+	User     string
+	Account  string
+	NoMask   bool
+	Password string
+	Role     string
+	Output   string
+}
+
+func GetUserInfoFromLoginCmdOptions(loginOptions LoginCmdOptions) serviceProviders.UserInfo {
+	user := serviceProviders.UserInfo{
+		Org:      loginOptions.Org,
+		User:     loginOptions.User,
+		Account:  loginOptions.Account,
+		NoMask:   loginOptions.NoMask,
+		Password: loginOptions.Password,
+		Role:     loginOptions.Role,
+	}
+	return user
+}
+
+func Login(idProvider identityProviders.IdentityProvider, consolerw console.ConsoleReader, loginOptions LoginCmdOptions) string {
+	loginOptions.User = getUserIfEmpty(consolerw, loginOptions.User)
+	user := GetUserInfoFromLoginCmdOptions(loginOptions)
+
+	_, err := authenticate(user, idProvider, consolerw)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return "Session created."
+}

--- a/login.go
+++ b/login.go
@@ -3,6 +3,7 @@ package bmx
 import (
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/rtkwlf/bmx/console"
 
@@ -45,5 +46,10 @@ func Login(idProvider *okta.OktaClient, consolerw console.ConsoleReader, loginOp
 	if !ok {
 		return fmt.Sprintf("Failed to create session for %s", loginOptions.User)
 	}
-	return fmt.Sprintf("Session for %s expires at %s", session.Userid, session.ExpiresAt)
+
+	expiresAt, err := time.Parse(time.RFC3339, session.ExpiresAt)
+	if err != nil {
+		fmt.Println(err)
+	}
+	return fmt.Sprintf("Session expires in %s", time.Until(expiresAt).Round(time.Second))
 }

--- a/saml/identityProviders/okta/okta.go
+++ b/saml/identityProviders/okta/okta.go
@@ -139,12 +139,12 @@ func (o *OktaClient) Authenticate(username, password, org string) (string, error
 }
 
 func (o *OktaClient) AuthenticateFromCache(username, org string) (string, bool) {
-	sessionID, ok := o.GetCachedOktaSession(username, org)
+	session, ok := o.GetCachedOktaSession(username, org)
 	if !ok {
 		return "", false
 	}
 
-	o.setSessionId(sessionID)
+	o.setSessionId(session.SessionId)
 
 	rel, _ := url.Parse(fmt.Sprintf("users/me"))
 	url := o.BaseUrl.ResolveReference(rel)
@@ -243,18 +243,19 @@ func (o *OktaClient) CacheOktaSession(userId, org, sessionId, expiresAt string) 
 	o.SessionCache.SaveSessions(existingSessions)
 }
 
-func (o *OktaClient) GetCachedOktaSession(userid, org string) (string, bool) {
+func (o *OktaClient) GetCachedOktaSession(userid, org string) (file.OktaSessionCache, bool) {
+	var result file.OktaSessionCache
 	oktaSessions, err := readOktaCacheSessionsFile(o)
 	if err != nil {
-		return "", false
+		return result, false
 	}
 	for _, oktaSession := range oktaSessions {
 		if oktaSession.Userid == userid &&
 			oktaSession.Org == org {
-			return oktaSession.SessionId, true
+			return oktaSession, true
 		}
 	}
-	return "", false
+	return result, false
 }
 
 func readOktaCacheSessionsFile(o *OktaClient) ([]file.OktaSessionCache, error) {


### PR DESCRIPTION
Introduce `login` command for creating a new session with Okta.

Sessions are created in the process of executing other commands (e.g. `print`, `credential-process`), while we have no explicit command for creating a new session. This enables an option for creating a session without needing to ignore the response.

This is related to an issue when developing when working in a non-interactive environment. In those cases, we need to login ahead of time to avoid any prompts. At the moment that can be done using `bmx print` and discarding the output (/dev/null).

The command inputs of `login` mirror that of `print` to match the UserInfo API. This can be refactored in future work to reduce the inputs.

