### PR TITLE
feat(cmd-config): Emit default config for user directory

### DIFF
--- a/cmd/bmx/BUILD.bazel
+++ b/cmd/bmx/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "bmx.go",
+        "config.go",
         "credential-process.go",
         "login.go",
         "print.go",
@@ -19,6 +20,7 @@ go_library(
         "//saml/identityProviders/okta:go_default_library",
         "//saml/serviceProviders/aws:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
+        "@in_gopkg_ini_v1//:go_default_library",
     ],
 )
 

--- a/cmd/bmx/config.go
+++ b/cmd/bmx/config.go
@@ -19,7 +19,7 @@ func init() {
 }
 
 var configCmd = &cobra.Command{
-	Use:   "config",
+	Use:   "ini-config",
 	Short: "Print a minimal configuration for use",
 	Run: func(cmd *cobra.Command, args []string) {
 		cfg := ini.Empty()

--- a/cmd/bmx/config.go
+++ b/cmd/bmx/config.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/rtkwlf/bmx/config"
+	"github.com/spf13/cobra"
+	"gopkg.in/ini.v1"
+)
+
+var configTemplate = config.NewUserConfig()
+
+func init() {
+	configCmd.Flags().StringVar(&configTemplate.Org, "org", "", "the okta org api to target")
+	configCmd.Flags().StringVar(&configTemplate.User, "user", "", "the user to authenticate with")
+
+	rootCmd.AddCommand(configCmd)
+}
+
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Print a minimal configuration for use",
+	Run: func(cmd *cobra.Command, args []string) {
+		cfg := ini.Empty()
+
+		section := cfg.Section("")
+		section.Key("org").SetValue(configTemplate.Org)
+		section.Key("user").SetValue(configTemplate.User)
+		section.Key("allow_project_configs").SetValue("true")
+
+		_, err := cfg.WriteTo(os.Stdout)
+		if err != nil {
+			log.Fatal(err)
+		}
+	},
+}


### PR DESCRIPTION
Emit an ini configuration file for mapping to a Okta organization and user.

This is intended to assist with automated configured of user environments by allowing for bmx to create a simple configuration file for a user. This doesn't do any mappings for other config options like account, which would need to be set by the user. When there is only a single AWS okta app, then bmx should default to selecting that option.

This allows for cases where the machine username matches the okta username, you can run this:

```
bmx config --org 'ACME' --user `id -n -u` > ~/.bmx/config
```

To fill in the details of the organization and user.
