### PR TITLE
refactor(authenticate): Generic option selection from authenticate

### DIFF
--- a/console.go
+++ b/console.go
@@ -96,7 +96,7 @@ func authenticate(user serviceProviders.UserInfo, oktaClient identityProviders.I
 		}
 
 		consolerw.Println("Available accounts:")
-		accountID, err := consolerw.Option("Select an account: ", appLabels, consolerw)
+		accountID, err := consolerw.Option("Select an account: ", appLabels)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/console.go
+++ b/console.go
@@ -65,22 +65,6 @@ func getPassword(consolerw console.ConsoleReader, noMask bool) string {
 	return pass
 }
 
-func selectPrompt(prompt string, options []string, consolerw console.ConsoleReader) (int, error) {
-	if len(options) < 1 {
-		return -1, fmt.Errorf("No options available for selection")
-	}
-
-	var selection int
-	for idx, option := range options {
-		consolerw.Println(fmt.Sprintf("[%d] %s", idx, option))
-	}
-	selection, err := consolerw.ReadInt(prompt)
-	if err != nil {
-		return -1, err
-	}
-	return selection, nil
-}
-
 func authenticate(user serviceProviders.UserInfo, oktaClient identityProviders.IdentityProvider, consolerw console.ConsoleReader) (string, error) {
 	var userID string
 	var ok bool
@@ -112,7 +96,7 @@ func authenticate(user serviceProviders.UserInfo, oktaClient identityProviders.I
 		}
 
 		consolerw.Println("Available accounts:")
-		accountID, err := selectPrompt("Select an account: ", appLabels, consolerw)
+		accountID, err := consolerw.Option("Select an account: ", appLabels, consolerw)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/console.go
+++ b/console.go
@@ -88,8 +88,13 @@ func authenticate(user serviceProviders.UserInfo, oktaClient identityProviders.I
 	}
 
 	app, found := findApp(user.Account, oktaApplications)
-	if !found {
-		// format account labels
+	if found {
+		return oktaClient.GetSaml(*app)
+	}
+
+	if len(oktaApplications) == 1 {
+		app = &oktaApplications[0]
+	} else {
 		appLabels := []string{}
 		for _, app := range oktaApplications {
 			appLabels = append(appLabels, app.Label)
@@ -100,7 +105,6 @@ func authenticate(user serviceProviders.UserInfo, oktaClient identityProviders.I
 		if err != nil {
 			log.Fatal(err)
 		}
-
 		app = &oktaApplications[accountID]
 	}
 

--- a/console.go
+++ b/console.go
@@ -66,6 +66,10 @@ func getPassword(consolerw console.ConsoleReader, noMask bool) string {
 }
 
 func selectPrompt(prompt string, options []string, consolerw console.ConsoleReader) (int, error) {
+	if len(options) < 1 {
+		return -1, fmt.Errorf("No options available for selection")
+	}
+
 	var selection int
 	for idx, option := range options {
 		consolerw.Println(fmt.Sprintf("[%d] %s", idx, option))
@@ -93,6 +97,10 @@ func authenticate(user serviceProviders.UserInfo, oktaClient identityProviders.I
 	oktaApplications, err := oktaClient.ListApplications(userID)
 	if err != nil {
 		log.Fatal(err)
+	}
+
+	if len(oktaApplications) < 1 {
+		log.Fatal(fmt.Errorf("No AWS okta applinks were found for userid:%s", userID))
 	}
 
 	app, found := findApp(user.Account, oktaApplications)

--- a/console/ConsoleReader.go
+++ b/console/ConsoleReader.go
@@ -15,6 +15,7 @@ type ConsoleReader interface {
 	ReadLine(prompt string) (string, error)
 	ReadPassword(prompt string) (string, error)
 	ReadInt(prompt string) (int, error)
+	Option(prompt string, options []string) (int, error)
 	Print(prompt string) error
 	Println(prompt string) error
 }
@@ -101,4 +102,20 @@ func (r *DefaultConsoleReader) ReadPassword(prompt string) (string, error) {
 	}
 
 	return string(pass[:]), nil
+}
+
+func (r *DefaultConsoleReader) Option(prompt string, options []string) (int, error) {
+	if len(options) < 1 {
+		return -1, fmt.Errorf("No options available for selection")
+	}
+
+	var selection int
+	for idx, option := range options {
+		r.Println(fmt.Sprintf("[%d] %s", idx, option))
+	}
+	selection, err := r.ReadInt(prompt)
+	if err != nil {
+		return -1, err
+	}
+	return selection, nil
 }

--- a/console/ConsoleReader.go
+++ b/console/ConsoleReader.go
@@ -109,6 +109,10 @@ func (r *DefaultConsoleReader) Option(prompt string, options []string) (int, err
 		return -1, fmt.Errorf("No options available for selection")
 	}
 
+	if len(options) == 1 {
+		return 0, nil
+	}
+
 	var selection int
 	for idx, option := range options {
 		r.Println(fmt.Sprintf("[%d] %s", idx, option))

--- a/mocks/consoleReader.go
+++ b/mocks/consoleReader.go
@@ -37,3 +37,7 @@ func (r ConsoleReaderMock) Println(prompt string) error {
 func (r ConsoleReaderMock) Print(prompt string) error {
 	return nil
 }
+
+func (r ConsoleReaderMock) Option(prompt string, options []string) (int, error) {
+	return 0, nil
+}

--- a/saml/identityProviders/okta/okta.go
+++ b/saml/identityProviders/okta/okta.go
@@ -169,7 +169,7 @@ func (o *OktaClient) AuthenticateFromCache(username, org string) (string, bool) 
 	return me.Id, true
 }
 
-func (o *OktaClient) ListApplications(userId string) ([]OktaAppLink, error) {
+func (o *OktaClient) ListAppLinks(userId string) ([]OktaAppLink, error) {
 	rel, _ := url.Parse(fmt.Sprintf("users/%s/appLinks", userId))
 	url := o.BaseUrl.ResolveReference(rel)
 
@@ -192,6 +192,21 @@ func (o *OktaClient) ListApplications(userId string) ([]OktaAppLink, error) {
 	}
 
 	return oktaApplications, nil
+}
+
+func (o *OktaClient) ListApplications(userId string) ([]OktaAppLink, error) {
+	oktaApplications, err := o.ListAppLinks(userId)
+	if err != nil {
+		return nil, err
+	}
+
+	applications := []OktaAppLink{}
+	for _, app := range oktaApplications {
+		if app.AppName == "amazon_aws" {
+			applications = append(applications, app)
+		}
+	}
+	return applications, nil
 }
 
 func (o *OktaClient) startSession(sessionToken string) (*OktaSessionResponse, error) {


### PR DESCRIPTION
Move the option selection from authenticate into its own method.

Authenticate has the logic for terminal option selection bundled into it. This removes that logic from the authenticate into its own `Option` command, with the aim of simplifying the `authenticate` method as a whole. Filtering for the AWS Okta apps have been migrated to the Okta priority level.

Additionally the new feature of selecting first if only one app-link is available.
