### PR TITLE
feat(config-mfa): Set multifactor type in user configuration

### DIFF
--- a/cmd/bmx/credential-process.go
+++ b/cmd/bmx/credential-process.go
@@ -67,6 +67,9 @@ func mergeProcessOptions(uc config.UserConfig, pc bmx.CredentialProcessCmdOption
 	if pc.Role == "" {
 		pc.Role = uc.Role
 	}
+	if pc.Factor == "" {
+		pc.Factor = uc.Factor
+	}
 
 	return pc
 }

--- a/cmd/bmx/login.go
+++ b/cmd/bmx/login.go
@@ -58,6 +58,9 @@ func mergeLoginOptions(uc config.UserConfig, pc bmx.LoginCmdOptions) bmx.LoginCm
 	if pc.Role == "" {
 		pc.Role = uc.Role
 	}
+	if pc.Factor == "" {
+		pc.Factor = uc.Factor
+	}
 
 	return pc
 }

--- a/cmd/bmx/print.go
+++ b/cmd/bmx/print.go
@@ -77,6 +77,9 @@ func mergePrintOptions(uc config.UserConfig, pc bmx.PrintCmdOptions) bmx.PrintCm
 	if pc.Role == "" {
 		pc.Role = uc.Role
 	}
+	if pc.Factor == "" {
+		pc.Factor = uc.Factor
+	}
 
 	return pc
 }

--- a/cmd/bmx/write.go
+++ b/cmd/bmx/write.go
@@ -81,8 +81,8 @@ func MergeWriteCmdOptions(uc config.UserConfig, wc bmx.WriteCmdOptions) bmx.Writ
 	if wc.Role == "" {
 		wc.Role = uc.Role
 	}
-	if pc.Factor == "" {
-		pc.Factor = uc.Factor
+	if wc.Factor == "" {
+		wc.Factor = uc.Factor
 	}
 
 	return wc

--- a/cmd/bmx/write.go
+++ b/cmd/bmx/write.go
@@ -81,6 +81,9 @@ func MergeWriteCmdOptions(uc config.UserConfig, wc bmx.WriteCmdOptions) bmx.Writ
 	if wc.Role == "" {
 		wc.Role = uc.Role
 	}
+	if pc.Factor == "" {
+		pc.Factor = uc.Factor
+	}
 
 	return wc
 }

--- a/config/loadConfig.go
+++ b/config/loadConfig.go
@@ -39,6 +39,7 @@ type UserConfig struct {
 	Account             string
 	Role                string
 	Profile             string
+	Factor              string
 }
 
 func NewUserConfig() UserConfig {

--- a/console.go
+++ b/console.go
@@ -72,7 +72,7 @@ func authenticate(user serviceProviders.UserInfo, oktaClient identityProviders.I
 	if !ok {
 		user.Password = getPassword(consolerw, user.NoMask)
 		var err error
-		userID, err = oktaClient.Authenticate(user.User, user.Password, user.Org)
+		userID, err = oktaClient.Authenticate(user.User, user.Password, user.Org, user.Factor)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/credential-process.go
+++ b/credential-process.go
@@ -20,6 +20,7 @@ type CredentialProcessCmdOptions struct {
 	Password string
 	Role     string
 	Output   string
+	Factor   string
 }
 
 type CredentialProcessResult struct {
@@ -38,6 +39,7 @@ func GetUserInfoFromCredentialProcessCmdOptions(printOptions CredentialProcessCm
 		NoMask:   printOptions.NoMask,
 		Password: printOptions.Password,
 		Role:     printOptions.Role,
+		Factor:   printOptions.Factor,
 	}
 	return user
 }

--- a/login.go
+++ b/login.go
@@ -18,6 +18,7 @@ type LoginCmdOptions struct {
 	NoMask   bool
 	Password string
 	Role     string
+	Factor   string
 }
 
 func GetUserInfoFromLoginCmdOptions(loginOptions LoginCmdOptions) serviceProviders.UserInfo {
@@ -28,6 +29,7 @@ func GetUserInfoFromLoginCmdOptions(loginOptions LoginCmdOptions) serviceProvide
 		NoMask:   loginOptions.NoMask,
 		Password: loginOptions.Password,
 		Role:     loginOptions.Role,
+		Factor:   loginOptions.Factor,
 	}
 	return user
 }

--- a/mocks/mokta.go
+++ b/mocks/mokta.go
@@ -26,7 +26,7 @@ type Mokta struct {
 	BaseUrl *url.URL
 }
 
-func (m *Mokta) Authenticate(username, password, org string) (string, error) {
+func (m *Mokta) Authenticate(username, password, org, factor string) (string, error) {
 	return "1", nil
 }
 

--- a/print.go
+++ b/print.go
@@ -40,6 +40,7 @@ type PrintCmdOptions struct {
 	Password string
 	Role     string
 	Output   string
+	Factor   string
 }
 
 func GetUserInfoFromPrintCmdOptions(printOptions PrintCmdOptions) serviceProviders.UserInfo {
@@ -50,6 +51,7 @@ func GetUserInfoFromPrintCmdOptions(printOptions PrintCmdOptions) serviceProvide
 		NoMask:   printOptions.NoMask,
 		Password: printOptions.Password,
 		Role:     printOptions.Role,
+		Factor:   printOptions.Factor,
 	}
 	return user
 }

--- a/saml/identityProviders/IdentityProvider.go
+++ b/saml/identityProviders/IdentityProvider.go
@@ -22,7 +22,7 @@ import (
 
 type IdentityProvider interface {
 	AuthenticateFromCache(username, org string) (string, bool)
-	Authenticate(username, password, org string) (string, error)
+	Authenticate(username, password, org, factor string) (string, error)
 	ListApplications(userId string) ([]okta.OktaAppLink, error)
 	GetSaml(appLink okta.OktaAppLink) (string, error)
 }

--- a/saml/identityProviders/okta/okta.go
+++ b/saml/identityProviders/okta/okta.go
@@ -410,14 +410,11 @@ func (o *OktaClient) doMfa(oktaAuthResponse *OktaAuthResponse, factor string) er
 	// mapped action form (e.g. actions[factortype] => perform action)
 	if selectedFactor.FactorType == "token:software:totp" {
 		err = o.verifyTotpMfa(oktaAuthResponse, selectedFactor)
-		if err != nil {
-			log.Fatal(err)
-		}
 	} else if selectedFactor.FactorType == "push" {
 		err = o.verifyPushMfa(oktaAuthResponse, selectedFactor)
-		if err != nil {
-			log.Fatal(err)
-		}
+	}
+	if err != nil {
+		log.Fatal(err)
 	}
 	return nil
 }

--- a/saml/identityProviders/okta/okta.go
+++ b/saml/identityProviders/okta/okta.go
@@ -412,6 +412,8 @@ func (o *OktaClient) doMfa(oktaAuthResponse *OktaAuthResponse, factor string) er
 		err = o.verifyTotpMfa(oktaAuthResponse, selectedFactor)
 	} else if selectedFactor.FactorType == "push" {
 		err = o.verifyPushMfa(oktaAuthResponse, selectedFactor)
+	} else {
+		err = fmt.Errorf("Selected MFA factor %s is not supported", selectedFactor.FactorType)
 	}
 	if err != nil {
 		log.Fatal(err)

--- a/saml/serviceProviders/UserInfo.go
+++ b/saml/serviceProviders/UserInfo.go
@@ -23,4 +23,5 @@ type UserInfo struct {
 	NoMask   bool
 	Password string
 	Role     string
+	Factor   string
 }

--- a/write.go
+++ b/write.go
@@ -37,6 +37,7 @@ type WriteCmdOptions struct {
 	Profile  string
 	Output   string
 	Role     string
+	Factor   string
 }
 
 func GetUserInfoFromWriteCmdOptions(writeOptions WriteCmdOptions) serviceProviders.UserInfo {
@@ -46,6 +47,7 @@ func GetUserInfoFromWriteCmdOptions(writeOptions WriteCmdOptions) serviceProvide
 		Account:  writeOptions.Account,
 		NoMask:   writeOptions.NoMask,
 		Password: writeOptions.Password,
+		Factor:   writeOptions.Factor,
 	}
 	return user
 }


### PR DESCRIPTION
Set the desired multi-factor type (`push` or `token:software:totp`) for use.

If available, the desired multi-factor type specified in the user configuration will be used when selecting a multi-factor type. If there is only one factor option supplied by Okta, then that factor will be selected by default. This allows for `~/.bmx/config` to contain the following:

```ini
factor = push
# or
factor = token:software:totp
```

Additional refactoring work has been done to leverage `.Option` for the multi-factor selection text, and some of the complexity of `doMfa` has been split out into `selectFactor`. Further refactoring work will be needed to reduce the impact of user config changes.