### PR TITLE
fix(console): Print newline after reading password

### DIFF
--- a/console/ConsoleReader.go
+++ b/console/ConsoleReader.go
@@ -101,6 +101,7 @@ func (r *DefaultConsoleReader) ReadPassword(prompt string) (string, error) {
 		return "", err
 	}
 
+	r.Println("")
 	return string(pass[:]), nil
 }
 


### PR DESCRIPTION
Print newline after reading password to fix line breaks for prompts.

Any text that follows the password prompt will land on the same line as the password prompt. Visually this can be jarring as it doesn't make it immediately obvious what the next prompt is asking (as its in an odd spot). This resolves this by adding a new line after the password is retrieved.

See below for an example of odd placement.

```
Okta Password:  Available MFA: 
```