### PR TITLE
docs(acknowledge): Missing acknowledgement of D2L

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ BMX manages your STS tokens with the following commands:
 
 BMX prints detailed usage information when you run `bmx -h` or `bmx <cmd> -h`.
 
+BMX was developed by D2L (Brightspace/bmx), and modifications have been made to the project by Arctic Wolf.
+
 ## Installation
 
 Available versions of BMX are available on the [releases](https://github.com/rtkwlf/bmx/releases) page. 


### PR DESCRIPTION
Add in a clear acknowledgement of the work done by D2L from the original project (Brightspace/bmx).

The project is missing a clear indication that D2L was the sole developer of bmx before modifications were made by members of Arctic Wolf (@rtkjbeverly). The project wasn't forked when it was originally experimented with during a hackathon, and until now it hasn't been noticed that the project was missing acknowledgements of this.

This adds in acknowledgements of this, but isn't complete.