### PR TITLE
build(ghactions): Simplify the action trigger globs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,13 +2,12 @@ name: Build & Test
 on:
   push:
     paths:
-      - "*.go"
-      - "*/*.go"
-      - "*/*/*.go"
-      - "*/*/*/*.go"
-      - "*/*/*/*/*.go"
-      - "*/*/*/*/*/*.go"
       - .github/workflows/main.yml
+      - "**/*.go"
+      - "**/*.bazel"
+      - ".bazelrc"
+      - "go.mod"
+      - "go.sum"
 
 jobs:
   test:


### PR DESCRIPTION
This simplifies the trigger globs for the build workflow, to remove the duplication of go file type triggers. 

This was setup as a workaround for issues with globs in GitHub Actions that was encountered in beta/preview, and has been resolved.

Additionally bazel resources and go dependency files have been added to this list of available triggers.

