### PR TITLE
refactor(console): Move message prompt for option into Option method

### DIFF
--- a/console.go
+++ b/console.go
@@ -100,8 +100,7 @@ func authenticate(user serviceProviders.UserInfo, oktaClient identityProviders.I
 			appLabels = append(appLabels, app.Label)
 		}
 
-		consolerw.Println("Available accounts:")
-		accountID, err := consolerw.Option("Select an account: ", appLabels)
+		accountID, err := consolerw.Option("Available accounts:", "Select an account: ", appLabels)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/console.go
+++ b/console.go
@@ -100,7 +100,11 @@ func authenticate(user serviceProviders.UserInfo, oktaClient identityProviders.I
 			appLabels = append(appLabels, app.Label)
 		}
 
-		accountID, err := consolerw.Option("Available accounts:", "Select an account: ", appLabels)
+		accountID, err := consolerw.Option(
+			"Available accounts:",
+			"Select an account: ",
+			appLabels,
+		)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/console/ConsoleReader.go
+++ b/console/ConsoleReader.go
@@ -15,7 +15,7 @@ type ConsoleReader interface {
 	ReadLine(prompt string) (string, error)
 	ReadPassword(prompt string) (string, error)
 	ReadInt(prompt string) (int, error)
-	Option(prompt string, options []string) (int, error)
+	Option(message string, prompt string, options []string) (int, error)
 	Print(prompt string) error
 	Println(prompt string) error
 }
@@ -105,7 +105,7 @@ func (r *DefaultConsoleReader) ReadPassword(prompt string) (string, error) {
 	return string(pass[:]), nil
 }
 
-func (r *DefaultConsoleReader) Option(prompt string, options []string) (int, error) {
+func (r *DefaultConsoleReader) Option(message string, prompt string, options []string) (int, error) {
 	if len(options) < 1 {
 		return -1, fmt.Errorf("No options available for selection")
 	}
@@ -114,7 +114,7 @@ func (r *DefaultConsoleReader) Option(prompt string, options []string) (int, err
 		return 0, nil
 	}
 
-	var selection int
+	r.Println(message)
 	for idx, option := range options {
 		r.Println(fmt.Sprintf("[%d] %s", idx, option))
 	}

--- a/mocks/consoleReader.go
+++ b/mocks/consoleReader.go
@@ -38,6 +38,6 @@ func (r ConsoleReaderMock) Print(prompt string) error {
 	return nil
 }
 
-func (r ConsoleReaderMock) Option(prompt string, options []string) (int, error) {
+func (r ConsoleReaderMock) Option(message string, prompt string, options []string) (int, error) {
 	return 0, nil
 }

--- a/saml/identityProviders/okta/okta.go
+++ b/saml/identityProviders/okta/okta.go
@@ -372,8 +372,7 @@ func (o *OktaClient) selectFactor(factors []OktaAuthFactors, desiredFactor strin
 		}
 	}
 
-	o.ConsoleReader.Println("MFA Required:")
-	mfaIdx, err := o.ConsoleReader.Option("Select an available MFA option: ", mfaLabels)
+	mfaIdx, err := o.ConsoleReader.Option("MFA Required:", "Select an available MFA option: ", mfaLabels)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/saml/identityProviders/okta/okta.go
+++ b/saml/identityProviders/okta/okta.go
@@ -372,7 +372,11 @@ func (o *OktaClient) selectFactor(factors []OktaAuthFactors, desiredFactor strin
 		}
 	}
 
-	mfaIdx, err := o.ConsoleReader.Option("MFA Required:", "Select an available MFA option: ", mfaLabels)
+	mfaIdx, err := o.ConsoleReader.Option(
+		"MFA Required:",
+		"Select an available MFA option: ",
+		mfaLabels,
+	)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Moves the message prompt for an option select into `Option`.

The message prompt is a component of the option itself, giving context to the choice. This change makes it easier to handle different models of input such as AppleScript in MacOS.