### PR TITLE
refactor(sessions): Use constant for sessions filename

### DIFF
--- a/saml/identityProviders/okta/file/oktaSession.go
+++ b/saml/identityProviders/okta/file/oktaSession.go
@@ -31,6 +31,10 @@ type OktaSessionCache struct {
 	ExpiresAt string `json:"expiresAt"`
 }
 
+const (
+	sessionFileName = "sessions"
+)
+
 type OktaSessionStorage struct{}
 
 func (o *OktaSessionStorage) SaveSessions(sessions []OktaSessionCache) {
@@ -39,11 +43,11 @@ func (o *OktaSessionStorage) SaveSessions(sessions []OktaSessionCache) {
 	if _, err := os.Stat(bmxHome); os.IsNotExist(err) {
 		os.MkdirAll(bmxHome, os.ModeDir|os.ModePerm)
 	}
-	ioutil.WriteFile(path.Join(userHomeDir(), ".bmx", "sessions"), sessionsJSON, 0644)
+	ioutil.WriteFile(path.Join(userHomeDir(), ".bmx", sessionFileName), sessionsJSON, 0644)
 }
 
 func (o *OktaSessionStorage) Sessions() ([]OktaSessionCache, error) {
-	sessionsFile, err := ioutil.ReadFile(path.Join(userHomeDir(), ".bmx", "sessions"))
+	sessionsFile, err := ioutil.ReadFile(path.Join(userHomeDir(), ".bmx", sessionFileName))
 	if os.IsNotExist(err) {
 		return nil, nil
 	}


### PR DESCRIPTION
Replace usage of sessions filename with a constant.

This matches the similar approach used for config and project file names. Additionally this makes it easier to change the name of the sessions file when wanting to experiment with bmx without impacting existing sessions.