### PR TITLE
refactor(saml-roles): Split SAML role selection from GetCredentials

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -22,6 +22,7 @@ go_library(
         "//saml/identityProviders:go_default_library",
         "//saml/identityProviders/okta:go_default_library",
         "//saml/serviceProviders:go_default_library",
+        "//saml/serviceProviders/aws:go_default_library",
         "@com_github_aws_aws_sdk_go//service/sts:go_default_library",
         "@in_gopkg_ini_v1//:go_default_library",
     ],

--- a/console/ConsoleReader.go
+++ b/console/ConsoleReader.go
@@ -106,7 +106,7 @@ func (r *DefaultConsoleReader) ReadPassword(prompt string) (string, error) {
 }
 
 func (r *DefaultConsoleReader) Option(message string, prompt string, options []string) (int, error) {
-	if len(options) < 1 {
+	if len(options) == 0 {
 		return -1, fmt.Errorf("No options available for selection")
 	}
 

--- a/credential-process.go
+++ b/credential-process.go
@@ -2,6 +2,7 @@ package bmx
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"time"
 
@@ -49,7 +50,11 @@ func GetUserInfoFromCredentialProcessCmdOptions(printOptions CredentialProcessCm
 func selectRoleFromSaml(saml string, desiredRole string, awsProvider serviceProviders.ServiceProvider, consolerw console.ConsoleReader) (role aws.AwsRole, err error) {
 	roles, err := awsProvider.ListRoles(saml)
 	if err != nil {
-		log.Fatal(err)
+		return role, err
+	}
+
+	if len(roles) == 0 {
+		return role, fmt.Errorf("No roles available from SAML")
 	}
 
 	if desiredRole == "" {

--- a/credential-process.go
+++ b/credential-process.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/rtkwlf/bmx/saml/serviceProviders/aws"
+
 	"github.com/rtkwlf/bmx/console"
 	"github.com/rtkwlf/bmx/saml/identityProviders"
 
@@ -44,6 +46,31 @@ func GetUserInfoFromCredentialProcessCmdOptions(printOptions CredentialProcessCm
 	return user
 }
 
+func selectRoleFromSaml(saml string, desiredRole string, awsProvider serviceProviders.ServiceProvider, consolerw console.ConsoleReader) (role aws.AwsRole, err error) {
+	roles, err := awsProvider.ListRoles(saml)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if desiredRole == "" {
+		roleLabels := []string{}
+		for _, role := range roles {
+			roleLabels = append(roleLabels, role.Name)
+		}
+
+		index, err := consolerw.Option("AWS Account Role", "Select a role: ", roleLabels)
+		if err != nil {
+			return role, err
+		}
+		desiredRole = roleLabels[index]
+	}
+	role, err = aws.FindAwsRoleByName(desiredRole, roles)
+	if err != nil {
+		return role, err
+	}
+	return role, nil
+}
+
 func CredentialProcess(idProvider identityProviders.IdentityProvider, awsProvider serviceProviders.ServiceProvider, consolerw console.ConsoleReader, printOptions CredentialProcessCmdOptions) string {
 	printOptions.User = getUserIfEmpty(consolerw, printOptions.User)
 	user := GetUserInfoFromCredentialProcessCmdOptions(printOptions)
@@ -53,7 +80,8 @@ func CredentialProcess(idProvider identityProviders.IdentityProvider, awsProvide
 		log.Fatal(err)
 	}
 
-	creds := awsProvider.GetCredentials(saml, printOptions.Role)
+	role, err := selectRoleFromSaml(saml, printOptions.Role, awsProvider, consolerw)
+	creds := awsProvider.GetCredentials(saml, role)
 	command := credentialProcessCommand(printOptions, creds)
 	return command
 }

--- a/credential-process.go
+++ b/credential-process.go
@@ -86,6 +86,9 @@ func CredentialProcess(idProvider identityProviders.IdentityProvider, awsProvide
 	}
 
 	role, err := selectRoleFromSaml(saml, printOptions.Role, awsProvider, consolerw)
+	if err != nil {
+		log.Fatal(err)
+	}
 	creds := awsProvider.GetCredentials(saml, role)
 	command := credentialProcessCommand(printOptions, creds)
 	return command

--- a/print.go
+++ b/print.go
@@ -67,6 +67,9 @@ func Print(idProvider identityProviders.IdentityProvider, awsProvider servicePro
 	}
 
 	role, err := selectRoleFromSaml(saml, printOptions.Role, awsProvider, consolerw)
+	if err != nil {
+		log.Fatal(err)
+	}
 	creds := awsProvider.GetCredentials(saml, role)
 
 	if printOptions.AssumeRole != "" {

--- a/print.go
+++ b/print.go
@@ -66,7 +66,8 @@ func Print(idProvider identityProviders.IdentityProvider, awsProvider servicePro
 		log.Fatal(err)
 	}
 
-	creds := awsProvider.GetCredentials(saml, printOptions.Role)
+	role, err := selectRoleFromSaml(saml, printOptions.Role, awsProvider, consolerw)
+	creds := awsProvider.GetCredentials(saml, role)
 
 	if printOptions.AssumeRole != "" {
 		creds, err = awsProvider.AssumeRole(*creds, printOptions.AssumeRole, printOptions.User)

--- a/saml/serviceProviders/BUILD.bazel
+++ b/saml/serviceProviders/BUILD.bazel
@@ -8,5 +8,8 @@ go_library(
     ],
     importpath = "github.com/rtkwlf/bmx/saml/serviceProviders",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_aws_aws_sdk_go//service/sts:go_default_library"],
+    deps = [
+        "//saml/serviceProviders/aws:go_default_library",
+        "@com_github_aws_aws_sdk_go//service/sts:go_default_library",
+    ],
 )

--- a/saml/serviceProviders/aws/mocks/BUILD.bazel
+++ b/saml/serviceProviders/aws/mocks/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/rtkwlf/bmx/saml/serviceProviders/aws/mocks",
     visibility = ["//visibility:public"],
     deps = [
+        "//saml/serviceProviders/aws:go_default_library",
         "@com_github_aws_aws_sdk_go//aws:go_default_library",
         "@com_github_aws_aws_sdk_go//service/sts:go_default_library",
     ],

--- a/saml/serviceProviders/aws/mocks/awsServiceProvider.go
+++ b/saml/serviceProviders/aws/mocks/awsServiceProvider.go
@@ -27,7 +27,7 @@ import (
 
 type AwsServiceProviderMock struct{}
 
-func (a AwsServiceProviderMock) GetCredentials(saml string, desiredRole string) *sts.Credentials {
+func (a AwsServiceProviderMock) GetCredentials(saml string, role bmxaws.AwsRole) *sts.Credentials {
 	return &sts.Credentials{
 		AccessKeyId:     aws.String("access_key_id"),
 		SecretAccessKey: aws.String("secret_access_key"),

--- a/saml/serviceProviders/aws/mocks/awsServiceProvider.go
+++ b/saml/serviceProviders/aws/mocks/awsServiceProvider.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sts"
+
+	bmxaws "github.com/rtkwlf/bmx/saml/serviceProviders/aws"
 )
 
 type AwsServiceProviderMock struct{}
@@ -36,4 +38,8 @@ func (a AwsServiceProviderMock) GetCredentials(saml string, desiredRole string) 
 
 func (a AwsServiceProviderMock) AssumeRole(creds sts.Credentials, targetRole string, sessionName string) (*sts.Credentials, error) {
 	return nil, nil
+}
+
+func (a AwsServiceProviderMock) ListRoles(saml string) (role []bmxaws.AwsRole, err error) {
+	return role, err
 }

--- a/saml/serviceProviders/aws/provider.go
+++ b/saml/serviceProviders/aws/provider.go
@@ -56,7 +56,7 @@ type AwsServiceProvider struct {
 	UserOutput  *os.File
 }
 
-func FindAwsRoleByName(name string, roles []AwsRole) (role AwsRole, err error) {
+func FindAwsRoleByName(name string, roles []AwsRole) (AwsRole, error) {
 	for _, role := range roles {
 		if strings.EqualFold(role.Name, name) {
 			return role, nil

--- a/saml/serviceProviders/aws/provider_test.go
+++ b/saml/serviceProviders/aws/provider_test.go
@@ -56,7 +56,9 @@ func TestMonkey(t *testing.T) {
 	// This is a base64 encoded minimal SAML input
 	saml := "PHNhbWxwOlJlc3BvbnNlPgogIDxzYW1sOkFzc2VydGlvbj4KICAgIDxzYW1sOkF0dHJpYnV0ZVN0YXRlbWVudD4KICAgICAgPHNhbWw6QXR0cmlidXRlIE5hbWU9Imh0dHBzOi8vYXdzLmFtYXpvbi5jb20vU0FNTC9BdHRyaWJ1dGVzL1JvbGUiPgogICAgICAgIDxzYW1sOkF0dHJpYnV0ZVZhbHVlIHhzaTp0eXBlPSJ4czpzdHJpbmciPkFybixyb2xlL1JvbGVBcm48L3NhbWw6QXR0cmlidXRlVmFsdWU+CiAgICAgIDwvc2FtbDpBdHRyaWJ1dGU+CiAgICA8L3NhbWw6QXR0cmlidXRlU3RhdGVtZW50PgogIDwvc2FtbDpBc3NlcnRpb24+Cjwvc2FtbHA6UmVzcG9uc2U+"
 
-	creds := provider.GetCredentials(saml, "RoleArn")
+	var role = awsService.AwsRole{}
+	role.Name = "RoleArn"
+	creds := provider.GetCredentials(saml, role)
 	if creds == nil {
 		panic("fail")
 	}

--- a/saml/serviceProviders/serviceProvider.go
+++ b/saml/serviceProviders/serviceProvider.go
@@ -22,7 +22,7 @@ import (
 )
 
 type ServiceProvider interface {
-	GetCredentials(saml string, desiredRole string) *sts.Credentials
+	GetCredentials(saml string, role aws.AwsRole) *sts.Credentials
 	ListRoles(saml string) ([]aws.AwsRole, error)
 	AssumeRole(creds sts.Credentials, targetRole string, sessionName string) (*sts.Credentials, error)
 }

--- a/saml/serviceProviders/serviceProvider.go
+++ b/saml/serviceProviders/serviceProvider.go
@@ -18,9 +18,11 @@ package serviceProviders
 
 import (
 	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/rtkwlf/bmx/saml/serviceProviders/aws"
 )
 
 type ServiceProvider interface {
 	GetCredentials(saml string, desiredRole string) *sts.Credentials
+	ListRoles(saml string) ([]aws.AwsRole, error)
 	AssumeRole(creds sts.Credentials, targetRole string, sessionName string) (*sts.Credentials, error)
 }

--- a/write.go
+++ b/write.go
@@ -62,6 +62,9 @@ func Write(idProvider identityProviders.IdentityProvider, awsProvider servicePro
 	}
 
 	role, err := selectRoleFromSaml(saml, writeOptions.Role, awsProvider, consolerw)
+	if err != nil {
+		log.Fatal(err)
+	}
 	creds := awsProvider.GetCredentials(saml, role)
 	writeToAwsCredentials(creds, writeOptions.Profile, resolvePath(writeOptions.Output))
 }

--- a/write.go
+++ b/write.go
@@ -61,7 +61,8 @@ func Write(idProvider identityProviders.IdentityProvider, awsProvider servicePro
 		log.Fatal(err)
 	}
 
-	creds := awsProvider.GetCredentials(saml, writeOptions.Role)
+	role, err := selectRoleFromSaml(saml, writeOptions.Role, awsProvider, consolerw)
+	creds := awsProvider.GetCredentials(saml, role)
 	writeToAwsCredentials(creds, writeOptions.Profile, resolvePath(writeOptions.Output))
 }
 


### PR DESCRIPTION
Split the selection of a SAML role from GetCredentials to better use `Option`.

This splits the selection of a SAML role from GetCredentials, moving the selection process out and passing in a resolved role. This refactoring was done as Option is needed in `pickRole` for the implementation of AppleScript in the MacOS case. While looking into the steps necessary for this, it made sense to move the role selection out of GetCredentials, and require a resolved SAML role to be passed in.

This does introduce issues where the concept of `AWS` is leaking from the serviceProvider abstraction. I'm comfortable with this for now to support alternative options of selection like AppleScript for MacOS. Changes will