### PR TITLE
refactor(aws): Remove the unused pickRoles function

### DIFF
--- a/saml/serviceProviders/aws/provider.go
+++ b/saml/serviceProviders/aws/provider.go
@@ -138,19 +138,6 @@ func (a AwsServiceProvider) AssumeRole(creds sts.Credentials, targetRole string,
 
 }
 
-func (a AwsServiceProvider) pickRole(roles []AwsRole) AwsRole {
-	if len(roles) == 1 {
-		return roles[0]
-	}
-
-	for i, role := range roles {
-		fmt.Fprintf(a.UserOutput, "[%d] %s\n", i, role.Name)
-	}
-	j, _ := a.InputReader.ReadInt("Select a role: ")
-
-	return roles[j]
-}
-
 func listRoles(samlResponse *Saml2pResponse) []AwsRole {
 	var roles []AwsRole
 	for _, v := range samlResponse.Assertion.AttributeStatement.Attributes {


### PR DESCRIPTION
Remove the unused pickRole functions that was missed in 123c230e38aca2e9bf3abb704367823964b802cc.
 
The aws provider is no longer responsible for identifying the SAML role. This responsibility is now managed by the caller, and is passed into the provider itself.