### PR TITLE
fix(totp): TOTP code cannot have trailing whitespace

### DIFF
--- a/console/ConsoleReader.go
+++ b/console/ConsoleReader.go
@@ -86,6 +86,10 @@ func (r *DefaultConsoleReader) ReadInt(prompt string) (int, error) {
 		return -1, err
 	}
 
+	if s == "" {
+		return -1, fmt.Errorf("Input is an empty string, and not valid")
+	}
+
 	var i int
 	if i, err = strconv.Atoi(s); err != nil {
 		return -1, err

--- a/saml/identityProviders/okta/okta.go
+++ b/saml/identityProviders/okta/okta.go
@@ -341,7 +341,7 @@ func (o *OktaClient) verifyTotpMfa(oktaAuthResponse *OktaAuthResponse, selectedF
 	if err != nil {
 		return err
 	}
-	body := fmt.Sprintf(`{"stateToken":"%s","passCode":"%s"}`, oktaAuthResponse.StateToken, code)
+	body := fmt.Sprintf(`{"stateToken":"%s","passCode":"%s"}`, oktaAuthResponse.StateToken, strings.TrimSpace(code)))
 	authResponse, err := o.HttpClient.Post(selectedFactor.Links.Verify.Url, "application/json", strings.NewReader(body))
 	if err != nil {
 		return err

--- a/saml/identityProviders/okta/okta.go
+++ b/saml/identityProviders/okta/okta.go
@@ -330,7 +330,7 @@ func (o *OktaClient) verifyPushMfa(oktaAuthResponse *OktaAuthResponse, selectedF
 	}
 
 	if !verified {
-		return fmt.Errorf("Failed to verify challenge within timeout window.")
+		return fmt.Errorf("Failed to verify challenge within timeout window")
 	}
 
 	return nil

--- a/saml/identityProviders/okta/okta.go
+++ b/saml/identityProviders/okta/okta.go
@@ -341,7 +341,7 @@ func (o *OktaClient) verifyTotpMfa(oktaAuthResponse *OktaAuthResponse, selectedF
 	if err != nil {
 		return err
 	}
-	body := fmt.Sprintf(`{"stateToken":"%s","passCode":"%s"}`, oktaAuthResponse.StateToken, strings.TrimSpace(code)))
+	body := fmt.Sprintf(`{"stateToken":"%s","passCode":"%s"}`, oktaAuthResponse.StateToken, strings.TrimSpace(code))
 	authResponse, err := o.HttpClient.Post(selectedFactor.Links.Verify.Url, "application/json", strings.NewReader(body))
 	if err != nil {
 		return err


### PR DESCRIPTION
The TOTP code sent to Okta cannot have trailing whitespace or it will fail to verify.

`ReadLine` does not trim trailing whitespace from inputs. For the console case this doesn't happen often, but for other input devices there may be trailing whitespace. ReadLine itself shouldn't trim whitespace as that may be intended for the input.