### PR TITLE
refactor(console): Refactor console for multiple input modes

### DIFF
--- a/cmd/bmx/bmx.go
+++ b/cmd/bmx/bmx.go
@@ -28,7 +28,7 @@ import (
 
 var (
 	userConfig config.UserConfig
-	consolerw  *console.ConsoleReader
+	consolerw  console.ConsoleReader
 )
 
 func init() {

--- a/cmd/bmx/bmx.go
+++ b/cmd/bmx/bmx.go
@@ -28,12 +28,12 @@ import (
 
 var (
 	userConfig config.UserConfig
-	consolerw  *console.DefaultConsoleReader
+	consolerw  *console.ConsoleReader
 )
 
 func init() {
 	userConfig = (config.ConfigLoader{}).LoadConfigs()
-	consolerw = console.NewConsoleReader()
+	consolerw = console.NewConsoleReader(false)
 }
 
 func main() {

--- a/cmd/bmx/credential-process.go
+++ b/cmd/bmx/credential-process.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/rtkwlf/bmx/config"
+	"github.com/rtkwlf/bmx/console"
 
 	"github.com/rtkwlf/bmx/saml/identityProviders/okta"
 	"github.com/rtkwlf/bmx/saml/serviceProviders/aws"
@@ -38,7 +39,7 @@ var processCmd = &cobra.Command{
 		// Override the output device for the edge case
 		// of credential-process. Until a more compatible option is selected,
 		// this will be used.
-		consolerw.Tty = true
+		consolerw = console.NewConsoleReader(true)
 
 		mergedOptions := mergeProcessOptions(userConfig, processOptions)
 

--- a/console/ConsoleReader.go
+++ b/console/ConsoleReader.go
@@ -24,9 +24,9 @@ type DefaultConsoleReader struct {
 	Tty bool
 }
 
-func NewConsoleReader() *DefaultConsoleReader {
+func NewConsoleReader(bool tty) *DefaultConsoleReader {
 	console := &DefaultConsoleReader{
-		Tty: false,
+		Tty: tty,
 	}
 	return console
 }

--- a/console/ConsoleReader.go
+++ b/console/ConsoleReader.go
@@ -24,8 +24,8 @@ type DefaultConsoleReader struct {
 	Tty bool
 }
 
-func NewConsoleReader(bool tty) *DefaultConsoleReader {
-	console := &DefaultConsoleReader{
+func NewConsoleReader(tty bool) DefaultConsoleReader {
+	console := DefaultConsoleReader{
 		Tty: tty,
 	}
 	return console
@@ -39,7 +39,7 @@ func openTty() (*os.File, error) {
 	return tty, nil
 }
 
-func (r *DefaultConsoleReader) Print(prompt string) error {
+func (r DefaultConsoleReader) Print(prompt string) error {
 	if r.Tty {
 		tty, err := openTty()
 		if err != nil {
@@ -52,7 +52,7 @@ func (r *DefaultConsoleReader) Print(prompt string) error {
 	}
 	return nil
 }
-func (r *DefaultConsoleReader) Println(prompt string) error {
+func (r DefaultConsoleReader) Println(prompt string) error {
 	if r.Tty {
 		tty, err := openTty()
 		if err != nil {
@@ -66,7 +66,7 @@ func (r *DefaultConsoleReader) Println(prompt string) error {
 	return nil
 }
 
-func (r *DefaultConsoleReader) ReadLine(prompt string) (string, error) {
+func (r DefaultConsoleReader) ReadLine(prompt string) (string, error) {
 	scanner := bufio.NewScanner(os.Stdin)
 	r.Print(prompt)
 
@@ -79,7 +79,7 @@ func (r *DefaultConsoleReader) ReadLine(prompt string) (string, error) {
 	return s, nil
 }
 
-func (r *DefaultConsoleReader) ReadInt(prompt string) (int, error) {
+func (r DefaultConsoleReader) ReadInt(prompt string) (int, error) {
 	var s string
 	var err error
 	if s, err = r.ReadLine(prompt); err != nil {
@@ -94,7 +94,7 @@ func (r *DefaultConsoleReader) ReadInt(prompt string) (int, error) {
 	return i, nil
 }
 
-func (r *DefaultConsoleReader) ReadPassword(prompt string) (string, error) {
+func (r DefaultConsoleReader) ReadPassword(prompt string) (string, error) {
 	r.Print(prompt)
 	pass, err := terminal.ReadPassword(int(syscall.Stdin))
 	if err != nil {
@@ -105,7 +105,7 @@ func (r *DefaultConsoleReader) ReadPassword(prompt string) (string, error) {
 	return string(pass[:]), nil
 }
 
-func (r *DefaultConsoleReader) Option(message string, prompt string, options []string) (int, error) {
+func (r DefaultConsoleReader) Option(message string, prompt string, options []string) (int, error) {
 	if len(options) == 0 {
 		return -1, fmt.Errorf("No options available for selection")
 	}

--- a/console/ConsoleReader.go
+++ b/console/ConsoleReader.go
@@ -11,17 +11,31 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
+// ConsoleReader is an interface for receiving user input.
 type ConsoleReader interface {
 	ReadLine(prompt string) (string, error)
 	ReadPassword(prompt string) (string, error)
 	ReadInt(prompt string) (int, error)
-	Option(message string, prompt string, options []string) (int, error)
-	Print(prompt string) error
-	Println(prompt string) error
+	Option(header string, prompt string, options []string) (int, error)
+	Print(message string) error
+	Println(message string) error
 }
 
+// DefaultConsoleReader is a console interface for emitting and receiving output.
 type DefaultConsoleReader struct {
 	Tty bool
+}
+
+// IsTtyAvailable attempts to open a tty connection, returning true if successful.
+//  console.IsTtyAvailable()  			// Check if tty can be opened
+//  result := console.IsTtyAvailable()  // Capture if tty is available
+func IsTtyAvailable() bool {
+	tty, err := openTty()
+	if err != nil {
+		return false
+	}
+	defer tty.Close()
+	return true
 }
 
 func NewConsoleReader(tty bool) DefaultConsoleReader {
@@ -39,33 +53,52 @@ func openTty() (*os.File, error) {
 	return tty, nil
 }
 
-func (r DefaultConsoleReader) Print(prompt string) error {
+// Print writes the message to the output channel.
+//  err := consolerw.Print("List of Items")        // Display text to the console.
+//
+// Parameters:
+//
+//  message string      // Required - The message to be written to console.
+func (r DefaultConsoleReader) Print(message string) error {
 	if r.Tty {
 		tty, err := openTty()
 		if err != nil {
 			log.Fatalf("Cannot open tty port: %v\n", err)
 		}
 		defer tty.Close()
-		fmt.Fprint(tty, prompt)
+		fmt.Fprint(tty, message)
 	} else {
-		fmt.Fprint(os.Stderr, prompt)
-	}
-	return nil
-}
-func (r DefaultConsoleReader) Println(prompt string) error {
-	if r.Tty {
-		tty, err := openTty()
-		if err != nil {
-			log.Fatalf("Cannot open tty port: %v\n", err)
-		}
-		defer tty.Close()
-		fmt.Fprintln(tty, prompt)
-	} else {
-		fmt.Fprintln(os.Stderr, prompt)
+		fmt.Fprint(os.Stderr, message)
 	}
 	return nil
 }
 
+// Println writes the message to the output channel with a newline.
+//  err := consolerw.Println("List of Items")        // Display text to the console.
+//
+// Parameters:
+//
+//  message string      // Required - The message to be written to console.
+func (r DefaultConsoleReader) Println(message string) error {
+	if r.Tty {
+		tty, err := openTty()
+		if err != nil {
+			log.Fatalf("Cannot open tty port: %v\n", err)
+		}
+		defer tty.Close()
+		fmt.Fprintln(tty, message)
+	} else {
+		fmt.Fprintln(os.Stderr, message)
+	}
+	return nil
+}
+
+// ReadLine prompts the console for input with a prompt.
+//  text, err := consolerw.ReadLine("Selection:")        // Prompt for selection
+//
+// Parameters:
+//
+//  prompt string      // Required - The prompt for input.
 func (r DefaultConsoleReader) ReadLine(prompt string) (string, error) {
 	scanner := bufio.NewScanner(os.Stdin)
 	r.Print(prompt)
@@ -79,6 +112,12 @@ func (r DefaultConsoleReader) ReadLine(prompt string) (string, error) {
 	return s, nil
 }
 
+// ReadInt prompts the console for an integer input with a prompt.
+//  index, err := consolerw.ReadInt("Selection:")        // Prompt for selection
+//
+// Parameters:
+//
+//  prompt string      // Required - The prompt for integer.
 func (r DefaultConsoleReader) ReadInt(prompt string) (int, error) {
 	var s string
 	var err error
@@ -94,6 +133,12 @@ func (r DefaultConsoleReader) ReadInt(prompt string) (int, error) {
 	return i, nil
 }
 
+// ReadPassword prompts the console for a password input with a prompt.
+//  passw, err := consolerw.ReadPassword("Password:")        // Prompt for password
+//
+// Parameters:
+//
+//  prompt string      // Required - The prompt for input.
 func (r DefaultConsoleReader) ReadPassword(prompt string) (string, error) {
 	r.Print(prompt)
 	pass, err := terminal.ReadPassword(int(syscall.Stdin))
@@ -105,7 +150,15 @@ func (r DefaultConsoleReader) ReadPassword(prompt string) (string, error) {
 	return string(pass[:]), nil
 }
 
-func (r DefaultConsoleReader) Option(message string, prompt string, options []string) (int, error) {
+// Option displays a list of options, prompting the console for a selection.
+//  consolerw.Option("Message text", "Action", []string{"hello", "world"})  // Display a list of hello and world, zero indexed for selection.
+//
+// Parameters:
+//
+//  header string     // Required - The header of the list selection
+//  prompt string      // Required - The prompt for input
+//  options string     // Required - The options given in the list
+func (r DefaultConsoleReader) Option(header string, prompt string, options []string) (int, error) {
 	if len(options) == 0 {
 		return -1, fmt.Errorf("No options available for selection")
 	}
@@ -114,7 +167,7 @@ func (r DefaultConsoleReader) Option(message string, prompt string, options []st
 		return 0, nil
 	}
 
-	r.Println(message)
+	r.Println(header)
 	for idx, option := range options {
 		r.Println(fmt.Sprintf("[%d] %s", idx, option))
 	}

--- a/console/ConsoleReader.go
+++ b/console/ConsoleReader.go
@@ -38,6 +38,13 @@ func IsTtyAvailable() bool {
 	return true
 }
 
+// NewConsoleReader creates a that reads from the console.
+//  reader := consolerw.NewConsoleReader(false)        // Write output to stderr
+//  reader := consolerw.NewConsoleReader(true)        // Write output to tty device
+//
+// Parameters:
+//
+//  tty bool      // Required - True if output should be written to tty; false otherwise.
 func NewConsoleReader(tty bool) DefaultConsoleReader {
 	console := DefaultConsoleReader{
 		Tty: tty,


### PR DESCRIPTION
Refactor console interface to better handle different input models.

The DefaultConsoleReader was built around working with terminal interfaces like zsh/bash/powershell. When support for `credential-process` was added, it was built with a narrow focus on usage from a console. This isn't always the case, and we need to be able to be flexible with where input is coming from, as `credential_process` isn't always invoked in the context of an interactive shell.

This lays the ground-work for supporting AppleScript in MacOS environments, which is the primary driver of this work.