### PR TITLE
doc(input): Configuration enum to control input behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ load this file automatically and populate the parameters where appropriate.
 | role | string | `-` | The AWS role to assume. |
 | profile | string | `-` | The profile to `write` in `~/.aws/credentials`. |
 | factor | `(push,token:software:totp)` | `-` | The desired multi-factor authentication factor-type to use. |
+| input | `(console,applescript,always_applescript)` | `console` | The intended behaviour for requesting user input. See (docs/input.md)[docs/input.md] |
 
 ### Project Scoped Configurations
 

--- a/docs/input.md
+++ b/docs/input.md
@@ -11,3 +11,7 @@ The available options are [`console`, `applescript`, `always_applescript`], with
 - `always_applescript` tries to use AppleScript for input always.
 
 The default input mode is `console`.
+
+## Non-interactive Context
+
+There may be a context where no interaction is possible (or accessible). In these cases `bmx login` can be used to retrieve a session ahead of time in an interactive context. If all needed input are provided, commands can then run in a non-interactive context.

--- a/docs/input.md
+++ b/docs/input.md
@@ -1,0 +1,13 @@
+# Input Modes
+
+Bmx supports the user configuration parameter `input` to control behaviour around requesting user input. There exist cases where Bmx is run with no guarantee of terminal input. An example of this would be in the AWSCLI (credential_process)[https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html] that sources credentials with an external process. To accomodate edge cases, bmx supports alternative input behaviours to ensure workflows continue without interruption.
+
+The configuration `input` has been made available to change the behaviour of input device selection. This is intended to address scenarios where the determination of an available tty is incorrect, and the interface option needs to be overwritten.
+
+The available options are [`console`, `applescript`, `always_applescript`], with the options described as such:
+
+- `console` tries to use the console first, then falls back on other input methods.
+- `applescript` tries to use the console first, and uses AppleScript first when in limited.
+- `always_applescript` tries to use AppleScript for input always.
+
+The default input mode is `console`.


### PR DESCRIPTION
Document the configuration enum `input` that controls input behaviour.

To accommodate some edge cases of `bmx` running in cases without access to a terminal, there is an input config that assists in controlling how input is sourced. This documents the options, and how they work in the system as a whole.