### PR TITLE
legal(license): Add AWN to license notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -188,6 +188,7 @@
       identification within third-party archives.
 
    Copyright 2019 D2L Corporation
+   Copyright 2020 Arctic Wolf Networks
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Add Arctic Wolf Networks to the repository license to reflect code changes by AWN.

The project license remains the same, but the attribution for work done by Arctic Wolf is added to the root license. 

The file headers in all cases have not been updated as part of this, as that should be done separately. My understanding is that the license headers are only a recommendation, and not a requirement of license. However as this is in a copyright realm, I'm erring on the side of absurd levels of caution.