### PR TITLE
build(devcontainers): Support devcontainer environments for development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,11 @@
+FROM gcr.io/cloud-marketplace-containers/google/bazel
+RUN apt-get update
+RUN apt-get install -y zsh && \
+    sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+
+ARG BAZEL_BUILDTOOLS_VERSION
+ARG BAZEL_BUILDTOOLS_URL="https://github.com/bazelbuild/buildtools/releases/download/"
+RUN curl -sSL "${BAZEL_BUILDTOOLS_URL}/${BAZEL_BUILDTOOLS_VERSION}/buildozer" > /usr/local/bin/buildozer && \
+    curl -sSL "${BAZEL_BUILDTOOLS_URL}/${BAZEL_BUILDTOOLS_VERSION}/buildifier" >  /usr/local/bin/buildifier && \
+    chmod +x /usr/local/bin/buildozer && \
+    chmod +x /usr/local/bin/buildifier 

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,16 @@
+# Try Out Development Containers: Go
+
+A **development container** is a running [Docker](https://www.docker.com) container with a well-defined tool/runtime stack and its prerequisites. You can try out development containers with **[Visual Studio Code Remote - Containers](https://aka.ms/vscode-remote/containers)**.
+
+This environment includes bazel and is intended to assist with isolation of bmx development to not interfere with existing bmx configurations.
+
+## Setting up the development container
+
+### VS Code Remote - Containers
+
+Follow these steps to open this sample in a container using the VS Code Remote - Containers extension:
+
+1. If this is your first time using a development container, please ensure your system meets the pre-reqs (i.e. have Docker installed) in the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started).
+
+2. Press <kbd>F1</kbd> and select the **Remote-Containers: Open Folder in Container...** command.
+3. Select the cloned copy of this folder, wait for the container to start, and try things out!

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+	"name": "Bazel",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			"BAZEL_BUILDTOOLS_VERSION": "3.5.0"
+		}
+	},
+	"settings": {
+		"terminal.integrated.shell.linux": "/usr/bin/zsh"
+	},
+	"extensions": [
+		"bazelbuild.vscode-bazel",
+		"esbenp.prettier-vscode",
+		"eamodio.gitlens",
+		"golang.go",
+		"redhat.vscode-yaml",
+		"ms-azuretools.vscode-docker"
+	],
+	"mounts": [
+		"source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind,consistency=cached"
+	]
+}


### PR DESCRIPTION
Enables a bazel devcontainer environment that can be used for isolated development.

This enables development in a docker container, which allows for isolation from the current `bmx` installation on a developer machine. This can be useful when attempting to avoid sessions or config clashes with already configured environments.

Bazel buildtools like buildifier and buildozer have been installed on the machine. The list of tools is in no way complete.