### PR TITLE
fix(print): Segment fault if cannot assume role

### DIFF
--- a/print.go
+++ b/print.go
@@ -75,7 +75,7 @@ func Print(idProvider identityProviders.IdentityProvider, awsProvider servicePro
 	if printOptions.AssumeRole != "" {
 		creds, err = awsProvider.AssumeRole(*creds, printOptions.AssumeRole, printOptions.User)
 		if err != nil {
-			log.Fatal(fmt.Errorf("Failed to assume role %s", printOptions.AssumeRole))
+			log.Fatal(fmt.Errorf("Could not assume role %s with current permissions", printOptions.AssumeRole))
 		}
 	}
 

--- a/print.go
+++ b/print.go
@@ -74,6 +74,9 @@ func Print(idProvider identityProviders.IdentityProvider, awsProvider servicePro
 
 	if printOptions.AssumeRole != "" {
 		creds, err = awsProvider.AssumeRole(*creds, printOptions.AssumeRole, printOptions.User)
+		if err != nil {
+			log.Fatal(fmt.Errorf("Failed to assume role %s", printOptions.AssumeRole))
+		}
 	}
 
 	command := printCommand(printOptions, creds)


### PR DESCRIPTION
If `print` cannot assume a role, then error instead of attempting to print invalid credentials.

This resolves the issue where if the `AssumeRole` cannot be assumed with the permissions of the AWS SSO Role, then it will attempt to print `nil` credentials, resulting in a segfault (`panic: runtime error: invalid memory address or nil pointer dereference`). This can reproduced by removing all policies from an SSO role, resulting in `AssumeRole` failing on permission denied.