### PR TITLE
fix(applescript): AppleScript prompts can raise concerns

### DIFF
--- a/console/AppleScript.go
+++ b/console/AppleScript.go
@@ -47,7 +47,7 @@ func (r AppleScriptConsole) Println(prompt string) error {
 func (r AppleScriptConsole) ReadLine(prompt string) (string, error) {
 	dialog := mack.DialogOptions{
 		Text:   prompt,
-		Title:  prompt,
+		Title:  fmt.Sprintf("BMX Prompt: %s", prompt),
 		Answer: " ",
 	}
 	response, err := mack.DialogBox(dialog)
@@ -70,7 +70,7 @@ func (r AppleScriptConsole) ReadLine(prompt string) (string, error) {
 func (r AppleScriptConsole) ReadInt(prompt string) (int, error) {
 	dialog := mack.DialogOptions{
 		Text:   prompt,
-		Title:  prompt,
+		Title:  fmt.Sprintf("BMX Prompt: %s", prompt),
 		Answer: " ",
 	}
 	response, err := mack.DialogBox(dialog)
@@ -99,7 +99,7 @@ func (r AppleScriptConsole) ReadInt(prompt string) (int, error) {
 func (r AppleScriptConsole) ReadPassword(prompt string) (string, error) {
 	dialog := mack.DialogOptions{
 		Text:         prompt,
-		Title:        prompt,
+		Title:        fmt.Sprintf("BMX Credential Request: %s", prompt),
 		HiddenAnswer: true,
 		Answer:       "123",
 	}
@@ -134,7 +134,7 @@ func (r AppleScriptConsole) Option(message string, prompt string, options []stri
 
 	listOptions := mack.ListOptions{
 		Items:   options,
-		Title:   message,
+		Title:  fmt.Sprintf("BMX Option Prompt: %s", message),
 		Message: prompt,
 	}
 	response, didCancel, err := mack.ListWithOpts(listOptions)


### PR DESCRIPTION
AppleScript prompts do not clearly indicate that they are from BMX, raising suspicions.

This add BMX to the AppleScript dialog box titles to ensure that users are aware of the context behind the prompt.

This has shown up when individuals open IntelliJ, and are suddenly prompted for their Okta password with no context behind what script/utility is doing the prompt. Individuals with context of the prompt, may understand that it is done by BMX, but this conditions users to input credentials into unknown/unclear prompts. We'd like to avoid that as much as possible.