### PR TITLE
feat(logout): Clear stored sessions

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -4,9 +4,9 @@ load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 pkg_tar(
     name = "package",
-    package_dir = "/",
-    srcs = ["//cmd/bmx:bmx"],
+    srcs = ["//cmd/bmx"],
     mode = "0755",
+    package_dir = "/",
 )
 
 # gazelle:prefix github.com/rtkwlf/bmx

--- a/cmd/bmx/BUILD.bazel
+++ b/cmd/bmx/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "config.go",
         "credential-process.go",
         "login.go",
+        "logout.go",
         "print.go",
         "version.go",
         "write.go",

--- a/cmd/bmx/logout.go
+++ b/cmd/bmx/logout.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/rtkwlf/bmx/config"
+
+	"github.com/rtkwlf/bmx/saml/identityProviders/okta"
+
+	"github.com/rtkwlf/bmx"
+	"github.com/spf13/cobra"
+)
+
+var logoutOptions = bmx.LoginCmdOptions{}
+
+func init() {
+	logoutCmd.Flags().StringVar(&logoutOptions.Org, "org", "", "the okta org api to target")
+	logoutCmd.Flags().StringVar(&logoutOptions.User, "user", "", "the user to authenticate with")
+	logoutCmd.Flags().StringVar(&logoutOptions.Account, "account", "", "the account name to auth against")
+	logoutCmd.Flags().StringVar(&logoutOptions.Role, "role", "", "the desired role to assume")
+	logoutCmd.Flags().BoolVar(&logoutOptions.NoMask, "nomask", false, "set to not mask the password. this helps with debugging.")
+
+	if userConfig.Org == "" {
+		logoutCmd.MarkFlagRequired("org")
+	}
+
+	rootCmd.AddCommand(logoutCmd)
+}
+
+var logoutCmd = &cobra.Command{
+	Use:   "logout",
+	Short: "Revokes the session",
+	Long:  `Forces revocation of the session`,
+	Run: func(cmd *cobra.Command, args []string) {
+		mergedOptions := mergeLogoutOptions(userConfig, logoutOptions)
+
+		oktaClient, err := okta.NewOktaClient(mergedOptions.Org, consolerw)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		response := bmx.Login(oktaClient, consolerw, mergedOptions)
+		fmt.Println(response)
+	},
+}
+
+func mergeLogoutOptions(uc config.UserConfig, pc bmx.LoginCmdOptions) bmx.LoginCmdOptions {
+	if pc.Org == "" {
+		pc.Org = uc.Org
+	}
+	if pc.User == "" {
+		pc.User = uc.User
+	}
+	if pc.Account == "" {
+		pc.Account = uc.Account
+	}
+	if pc.Role == "" {
+		pc.Role = uc.Role
+	}
+	if pc.Factor == "" {
+		pc.Factor = uc.Factor
+	}
+
+	return pc
+}

--- a/cmd/bmx/logout.go
+++ b/cmd/bmx/logout.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/rtkwlf/bmx/config"
@@ -12,15 +11,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var logoutOptions = bmx.LoginCmdOptions{}
+var logoutOptions = bmx.LogoutCmdOptions{}
 
 func init() {
 	logoutCmd.Flags().StringVar(&logoutOptions.Org, "org", "", "the okta org api to target")
-	logoutCmd.Flags().StringVar(&logoutOptions.User, "user", "", "the user to authenticate with")
-	logoutCmd.Flags().StringVar(&logoutOptions.Account, "account", "", "the account name to auth against")
-	logoutCmd.Flags().StringVar(&logoutOptions.Role, "role", "", "the desired role to assume")
-	logoutCmd.Flags().BoolVar(&logoutOptions.NoMask, "nomask", false, "set to not mask the password. this helps with debugging.")
-
 	if userConfig.Org == "" {
 		logoutCmd.MarkFlagRequired("org")
 	}
@@ -30,37 +24,22 @@ func init() {
 
 var logoutCmd = &cobra.Command{
 	Use:   "logout",
-	Short: "Revokes the session",
-	Long:  `Forces revocation of the session`,
+	Short: "Revokes all Okta sessions",
+	Long:  `Forces revocation of the Okta sessions`,
 	Run: func(cmd *cobra.Command, args []string) {
 		mergedOptions := mergeLogoutOptions(userConfig, logoutOptions)
-
 		oktaClient, err := okta.NewOktaClient(mergedOptions.Org, consolerw)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		response := bmx.Login(oktaClient, consolerw, mergedOptions)
-		fmt.Println(response)
+		bmx.Logout(oktaClient)
 	},
 }
 
-func mergeLogoutOptions(uc config.UserConfig, pc bmx.LoginCmdOptions) bmx.LoginCmdOptions {
+func mergeLogoutOptions(uc config.UserConfig, pc bmx.LogoutCmdOptions) bmx.LogoutCmdOptions {
 	if pc.Org == "" {
 		pc.Org = uc.Org
 	}
-	if pc.User == "" {
-		pc.User = uc.User
-	}
-	if pc.Account == "" {
-		pc.Account = uc.Account
-	}
-	if pc.Role == "" {
-		pc.Role = uc.Role
-	}
-	if pc.Factor == "" {
-		pc.Factor = uc.Factor
-	}
-
 	return pc
 }

--- a/login.go
+++ b/login.go
@@ -21,6 +21,10 @@ type LoginCmdOptions struct {
 	Factor   string
 }
 
+type LogoutCmdOptions struct {
+	Org      string
+}
+
 func GetUserInfoFromLoginCmdOptions(loginOptions LoginCmdOptions) serviceProviders.UserInfo {
 	user := serviceProviders.UserInfo{
 		Org:      loginOptions.Org,
@@ -53,4 +57,8 @@ func Login(idProvider *okta.OktaClient, consolerw console.ConsoleReader, loginOp
 		fmt.Println(err)
 	}
 	return fmt.Sprintf("Session expires in %s", time.Until(expiresAt).Round(time.Second))
+}
+
+func Logout(idProvider *okta.OktaClient) {
+	idProvider.ClearCachedOktaSession()
 }

--- a/login.go
+++ b/login.go
@@ -22,7 +22,7 @@ type LoginCmdOptions struct {
 }
 
 type LogoutCmdOptions struct {
-	Org      string
+	Org string
 }
 
 func GetUserInfoFromLoginCmdOptions(loginOptions LoginCmdOptions) serviceProviders.UserInfo {

--- a/saml/identityProviders/okta/file/oktaSession.go
+++ b/saml/identityProviders/okta/file/oktaSession.go
@@ -37,6 +37,16 @@ const (
 
 type OktaSessionStorage struct{}
 
+func (o *OktaSessionStorage) ClearSessions() {
+	sessions := make([]OktaSessionCache, 0)
+	sessionsJSON, _ := json.Marshal(sessions)
+	bmxHome := path.Join(userHomeDir(), ".bmx")
+	if _, err := os.Stat(bmxHome); os.IsNotExist(err) {
+		os.MkdirAll(bmxHome, os.ModeDir|os.ModePerm)
+	}
+	ioutil.WriteFile(path.Join(userHomeDir(), ".bmx", sessionFileName), sessionsJSON, 0644)
+}
+
 func (o *OktaSessionStorage) SaveSessions(sessions []OktaSessionCache) {
 	sessionsJSON, _ := json.Marshal(sessions)
 	bmxHome := path.Join(userHomeDir(), ".bmx")

--- a/saml/identityProviders/okta/mocks/mocks.go
+++ b/saml/identityProviders/okta/mocks/mocks.go
@@ -21,15 +21,22 @@ import (
 )
 
 type SessionCache struct {
-	SaveSessionsFn        func(session []file.OktaSessionCache)
-	SaveSessionsFnInvoked bool
-	SessionsFn            func() ([]file.OktaSessionCache, error)
-	SessionsFnInvoked     bool
+	ClearSessionsFn        func()
+	ClearSessionsFnInvoked bool
+	SaveSessionsFn         func(session []file.OktaSessionCache)
+	SaveSessionsFnInvoked  bool
+	SessionsFn             func() ([]file.OktaSessionCache, error)
+	SessionsFnInvoked      bool
 }
 
 func (s *SessionCache) SaveSessions(sessions []file.OktaSessionCache) {
 	s.SaveSessionsFnInvoked = true
 	s.SaveSessionsFn(sessions)
+}
+
+func (s *SessionCache) ClearSessions() {
+	s.ClearSessionsFnInvoked = true
+	s.ClearSessionsFn()
 }
 
 func (s *SessionCache) Sessions() ([]file.OktaSessionCache, error) {
@@ -39,7 +46,8 @@ func (s *SessionCache) Sessions() ([]file.OktaSessionCache, error) {
 
 func DefaultSessionCache() SessionCache {
 	return SessionCache{
-		SaveSessionsFn: func(session []file.OktaSessionCache) {},
-		SessionsFn:     func() ([]file.OktaSessionCache, error) { return nil, nil },
+		ClearSessionsFn: func() {},
+		SaveSessionsFn:  func(session []file.OktaSessionCache) {},
+		SessionsFn:      func() ([]file.OktaSessionCache, error) { return nil, nil },
 	}
 }

--- a/saml/identityProviders/okta/okta.go
+++ b/saml/identityProviders/okta/okta.go
@@ -66,6 +66,7 @@ func NewOktaClient(org string, consolerw console.ConsoleReader) (*OktaClient, er
 }
 
 type SessionCache interface {
+	ClearSessions()
 	SaveSessions(sessions []file.OktaSessionCache)
 	Sessions() ([]file.OktaSessionCache, error)
 }
@@ -271,6 +272,10 @@ func (o *OktaClient) GetCachedOktaSession(userid, org string) (file.OktaSessionC
 		}
 	}
 	return result, false
+}
+
+func (o *OktaClient) ClearCachedOktaSession() {
+	o.SessionCache.ClearSessions()
 }
 
 func readOktaCacheSessionsFile(o *OktaClient) ([]file.OktaSessionCache, error) {


### PR DESCRIPTION
Introduce a `logout` command for clearing the sessions file.

This introduces a `logout` command to have a managed way of clearing out the `sessions` file. There are some edge cases, where an invalid token (or soon to be expired token) is used to communicate with Okta. The solution at present is to clear or delete the sessions file (`~/.bmx/sessions`).

The `logout` command adds a more managed way of doing this, till the exact cause of this issue can be resolved.