### PR TITLE
refactor(sessions): Reduce code duplication on sessions

### DIFF
--- a/saml/identityProviders/okta/file/oktaSession.go
+++ b/saml/identityProviders/okta/file/oktaSession.go
@@ -63,7 +63,7 @@ func (o *OktaSessionStorage) Sessions() ([]OktaSessionCache, error) {
 	return sessions, nil
 }
 
-func writeSessionFile(json string) error {
+func writeSessionFile(json []byte) error {
 	bmxHome := bmxHomeDir()
 	if _, err := os.Stat(bmxHome); os.IsNotExist(err) {
 		os.MkdirAll(bmxHome, os.ModeDir|os.ModePerm)
@@ -73,7 +73,7 @@ func writeSessionFile(json string) error {
 }
 
 func sessionsFilePath() string {
-	return path.join(bmxHomeDir(), sessionFileName)
+	return path.Join(bmxHomeDir(), sessionFileName)
 }
 
 func bmxHomeDir() string {

--- a/saml/identityProviders/okta/file/oktaSession.go
+++ b/saml/identityProviders/okta/file/oktaSession.go
@@ -32,6 +32,7 @@ type OktaSessionCache struct {
 }
 
 const (
+	configDirName   = ".bmx"
 	sessionFileName = "sessions"
 )
 
@@ -44,20 +45,20 @@ func (o *OktaSessionStorage) ClearSessions() {
 	if _, err := os.Stat(bmxHome); os.IsNotExist(err) {
 		os.MkdirAll(bmxHome, os.ModeDir|os.ModePerm)
 	}
-	ioutil.WriteFile(path.Join(userHomeDir(), ".bmx", sessionFileName), sessionsJSON, 0644)
+	ioutil.WriteFile(sessionsFilePath(), sessionsJSON, 0644)
 }
 
 func (o *OktaSessionStorage) SaveSessions(sessions []OktaSessionCache) {
 	sessionsJSON, _ := json.Marshal(sessions)
-	bmxHome := path.Join(userHomeDir(), ".bmx")
+	bmxHome := bmxHomeDir()
 	if _, err := os.Stat(bmxHome); os.IsNotExist(err) {
 		os.MkdirAll(bmxHome, os.ModeDir|os.ModePerm)
 	}
-	ioutil.WriteFile(path.Join(userHomeDir(), ".bmx", sessionFileName), sessionsJSON, 0644)
+	ioutil.WriteFile(sessionsFilePath(), sessionsJSON, 0644)
 }
 
 func (o *OktaSessionStorage) Sessions() ([]OktaSessionCache, error) {
-	sessionsFile, err := ioutil.ReadFile(path.Join(userHomeDir(), ".bmx", sessionFileName))
+	sessionsFile, err := ioutil.ReadFile(sessionsFilePath())
 	if os.IsNotExist(err) {
 		return nil, nil
 	}
@@ -67,6 +68,14 @@ func (o *OktaSessionStorage) Sessions() ([]OktaSessionCache, error) {
 	var sessions []OktaSessionCache
 	json.Unmarshal([]byte(sessionsFile), &sessions)
 	return sessions, nil
+}
+
+func sessionsFilePath() string {
+	return path.join(bmxHomeDir(), sessionFileName)
+}
+
+func bmxHomeDir() string {
+	return path.Join(userHomeDir(), configDirName)
 }
 
 func userHomeDir() string {

--- a/saml/identityProviders/okta/file/oktaSession.go
+++ b/saml/identityProviders/okta/file/oktaSession.go
@@ -70,6 +70,15 @@ func (o *OktaSessionStorage) Sessions() ([]OktaSessionCache, error) {
 	return sessions, nil
 }
 
+func writeSessionFile(file string) error {
+	bmxHome := bmxHomeDir()
+	if _, err := os.Stat(bmxHome); os.IsNotExist(err) {
+		os.MkdirAll(bmxHome, os.ModeDir|os.ModePerm)
+	}
+	err := ioutil.WriteFile(sessionsFilePath(), sessionsJSON, 0644)
+	return err
+}
+
 func sessionsFilePath() string {
 	return path.join(bmxHomeDir(), sessionFileName)
 }

--- a/saml/identityProviders/okta/file/oktaSession.go
+++ b/saml/identityProviders/okta/file/oktaSession.go
@@ -41,20 +41,13 @@ type OktaSessionStorage struct{}
 func (o *OktaSessionStorage) ClearSessions() {
 	sessions := make([]OktaSessionCache, 0)
 	sessionsJSON, _ := json.Marshal(sessions)
-	bmxHome := path.Join(userHomeDir(), ".bmx")
-	if _, err := os.Stat(bmxHome); os.IsNotExist(err) {
-		os.MkdirAll(bmxHome, os.ModeDir|os.ModePerm)
-	}
-	ioutil.WriteFile(sessionsFilePath(), sessionsJSON, 0644)
+
+	writeSessionFile(sessionsJSON)
 }
 
 func (o *OktaSessionStorage) SaveSessions(sessions []OktaSessionCache) {
 	sessionsJSON, _ := json.Marshal(sessions)
-	bmxHome := bmxHomeDir()
-	if _, err := os.Stat(bmxHome); os.IsNotExist(err) {
-		os.MkdirAll(bmxHome, os.ModeDir|os.ModePerm)
-	}
-	ioutil.WriteFile(sessionsFilePath(), sessionsJSON, 0644)
+	writeSessionFile(sessionsJSON)
 }
 
 func (o *OktaSessionStorage) Sessions() ([]OktaSessionCache, error) {
@@ -70,12 +63,12 @@ func (o *OktaSessionStorage) Sessions() ([]OktaSessionCache, error) {
 	return sessions, nil
 }
 
-func writeSessionFile(file string) error {
+func writeSessionFile(json string) error {
 	bmxHome := bmxHomeDir()
 	if _, err := os.Stat(bmxHome); os.IsNotExist(err) {
 		os.MkdirAll(bmxHome, os.ModeDir|os.ModePerm)
 	}
-	err := ioutil.WriteFile(sessionsFilePath(), sessionsJSON, 0644)
+	err := ioutil.WriteFile(sessionsFilePath(), json, 0644)
 	return err
 }
 


### PR DESCRIPTION
Reduce duplicate construction of filepaths & writing to sessions files

This reduces the amount of duplication with generating the filepath for the sessions file, and consolidating the writing of the session file into a single method.

---

This is a minor refactoring, but I think some of the code in this space could be refactored about to be less reliant on the Okta integration. As I investigate the stale okta token issue, I'll explore this some more.

