### PR TITLE
fix(credential-processs): Remove initial tty available check

### DIFF
--- a/cmd/bmx/bmx_default.go
+++ b/cmd/bmx/bmx_default.go
@@ -3,20 +3,11 @@
 package main
 
 import (
-	"log"
 
 	"github.com/rtkwlf/bmx/config"
 	"github.com/rtkwlf/bmx/console"
 )
 
 func selectConsoleReader(userConfig config.UserConfig, limited bool) console.ConsoleReader {
-	if !limited {
-		return console.NewConsoleReader(false)
-	}
-
-	if !console.IsTtyAvailable() {
-		log.Fatal("Cannot create tty connection for writing output")
-	}
-
-	return console.NewConsoleReader(true)
+	return console.NewConsoleReader(limited)
 }


### PR DESCRIPTION
**Description:** Rather than check for the ability to create a tty
connection and failing if we can't, continue as if we have one. In the
case where we have a valid session, we don't need the tty, so the
credential-process command will continue to work. If we need to use the
tty (because no valid session), we already are raising an error, so let
it fail then.

**Testing:** `bazel test //...` and manually testing locally