### PR TITLE
docs(contrib): Touchups to internal instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,21 +2,23 @@
 
 ## Contributing
 
-1. **Fork** the repository. Committing directly against this repository is
-   highly discouraged.
+*Members of the AWN (rtkwlf) organization should consult internal documentation on contribution guidelines for repositories within rtkwlf.*
 
-2. Make your modifications in a branch, updating and writing new tests.
+Pull requests are the best way to propose changes to the codebase (use [Github Flow](https://guides.github.com/introduction/flow/index.html)). We actively welcome your pull requests:
 
-3. Ensure that all tests pass.
-
-4. `rebase` your changes against master. *Do not merge*.
-
+1. Fork the repo and create your branch from `main`.
+2. If you've added code that should be tested, add tests.
+3. If you've changed APIs, update the documentation.
+4. Ensure that all tests pass.
 5. Squash commits into one meaningful change per commit.
+6. Submit a pull request to this repository. Wait for tests to run and someone to chime in.
 
-6. Submit a pull request to this repository. Wait for tests to run and someone
-   to chime in.
+## Report bugs using Github's [issues](https://github.com/rtkwlf/bmx/issues)
+
+This repository uses GitHub issues to track public bugs. Members of the AWN (rtkwlf) organization should use our internal ticketing system, rather than using GitHub issues.
+
+Report a bug by [opening a new issue]().
 
 ## Coding Style
 
-This repository is configured with [EditorConfig](http://editorconfig.org) rules and
-contributions should make use of them.
+This repository is configured with [EditorConfig](http://editorconfig.org) rules and contributions should make use of them.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Contributing
 
-*Members of the AWN (rtkwlf) organization should consult internal documentation on contribution guidelines for repositories within rtkwlf.*
+*Members of the AWN (rtkwlf) organization should consult internal contribution guidelines for repositories within rtkwlf.*
 
 Pull requests are the best way to propose changes to the codebase (use [Github Flow](https://guides.github.com/introduction/flow/index.html)). We actively welcome your pull requests:
 
@@ -17,7 +17,7 @@ Pull requests are the best way to propose changes to the codebase (use [Github F
 
 This repository uses GitHub issues to track public bugs. Members of the AWN (rtkwlf) organization should use our internal ticketing system, rather than using GitHub issues.
 
-Report a bug by [opening a new issue]().
+Report a bug by [opening a new issue](https://github.com/rtkwlf/bmx/issues/new).
 
 ## Coding Style
 


### PR DESCRIPTION
Touchup the contribution policy to clarify how members of AWN (rtkwlf) should contribute to the repository.

This clarifies that for AWN members the internal guidelines for making changes to this repository apply (defaulting to using branches on the repository rather than forking), as well as our internal ticketing system should be used instead of GitHub actions.

Individuals external to the organization can make use of GitHub Issues for bug reports, and forking the repository to make changes.