### PR TITLE
fix(applescript): Support empty string default

### DIFF
--- a/config/loadConfig.go
+++ b/config/loadConfig.go
@@ -95,7 +95,7 @@ func (d ConfigLoader) LoadConfigs() UserConfig {
 }
 
 func (d ConfigLoader) getUserConfig() string {
-	userConfig := filepath.ToSlash(path.Join(d.UserDir(), ".bmx", configFileName))
+	userConfig := filepath.ToSlash(path.Join(d.UserDir(), projectFileName, configFileName))
 	if _, err := os.Stat(userConfig); err == nil {
 		return userConfig
 	}

--- a/console/AppleScript.go
+++ b/console/AppleScript.go
@@ -101,7 +101,7 @@ func (r AppleScriptConsole) ReadPassword(prompt string) (string, error) {
 		Text:         prompt,
 		Title:        fmt.Sprintf("BMX Credential Request: %s", prompt),
 		HiddenAnswer: true,
-		Answer:       "123",
+		Answer:       "",
 	}
 	response, err := mack.DialogBox(dialog)
 	if err != nil {

--- a/console/AppleScript.go
+++ b/console/AppleScript.go
@@ -48,7 +48,7 @@ func (r AppleScriptConsole) ReadLine(prompt string) (string, error) {
 	dialog := mack.DialogOptions{
 		Text:   prompt,
 		Title:  fmt.Sprintf("BMX Prompt: %s", prompt),
-		Answer: " ",
+		Answer: "",
 	}
 	response, err := mack.DialogBox(dialog)
 	if err != nil {
@@ -71,7 +71,7 @@ func (r AppleScriptConsole) ReadInt(prompt string) (int, error) {
 	dialog := mack.DialogOptions{
 		Text:   prompt,
 		Title:  fmt.Sprintf("BMX Prompt: %s", prompt),
-		Answer: " ",
+		Answer: "",
 	}
 	response, err := mack.DialogBox(dialog)
 	if err != nil {

--- a/vendor/github.com/andybrewer/mack/dialog.go
+++ b/vendor/github.com/andybrewer/mack/dialog.go
@@ -1,13 +1,13 @@
 /*
 ** Mack: Alert
 ** Create a desktop dialog box
-*/
+ */
 
 package mack
 
 import (
-  "strconv"
-  "strings"
+	"strconv"
+	"strings"
 )
 
 // Dialog triggers a desktop dialog box. Either an error is returned, or the string output from the user interaction.
@@ -25,25 +25,25 @@ import (
 //  answer string     // Optional - The default text in the input field
 //  duration string   // Optional - The number of seconds to wait for a user response
 func Dialog(text string, options ...string) (Response, error) {
-  return runWithButtons(buildDialog(text, options))
+	return runWithButtons(buildDialog(text, options))
 }
 
 // Parse the dialog options and build the command
 func buildDialog(text string, options []string) string {
-  text = wrapInQuotes(text)
+	text = wrapInQuotes(text)
 
-  var title, answer, duration string
-  if len(options) > 0 && options[0] != "" {
-    title = "with title " + wrapInQuotes(options[0])
-  }
-  if len(options) > 1 && options[1] != "" {
-    answer = "default answer " + wrapInQuotes(options[1])
-  }
-  if len(options) > 2 && options[2] != "" {
-    duration = "giving up after " + options[2]
-  }
+	var title, answer, duration string
+	if len(options) > 0 && options[0] != "" {
+		title = "with title " + wrapInQuotes(options[0])
+	}
+	if len(options) > 1 && options[1] != "" {
+		answer = "default answer " + wrapInQuotes(options[1])
+	}
+	if len(options) > 2 && options[2] != "" {
+		duration = "giving up after " + options[2]
+	}
 
-  return build("display dialog", text, title, answer, duration)
+	return build("display dialog", text, title, answer, duration)
 }
 
 // DialogBox triggers a desktop dialog box with the option for custom buttons. Either an error is returned, or the string output from the user interaction.
@@ -59,56 +59,58 @@ func buildDialog(text string, options []string) string {
 //  }
 //  response, err := mack.DialogBox(dialog)   // Display a dialog with the DialogBox settings, returns an error and Response
 func DialogBox(dialog DialogOptions) (Response, error) {
-  return runWithButtons(buildDialogBox(dialog))
+	return runWithButtons(buildDialogBox(dialog))
 }
 
 // Parse the DialogBox options and build the command
 func buildDialogBox(dialog DialogOptions) string {
-  var title, answer, hiddenAnswer, icon, duration, buttons, defaultButton string
-  text := wrapInQuotes(dialog.Text)
+	var title, answer, hiddenAnswer, icon, duration, buttons, defaultButton string
+	text := wrapInQuotes(dialog.Text)
 
-  if dialog.Title != "" {
-    title = "with title " + wrapInQuotes(dialog.Title)
-  }
-  if dialog.Answer != "" {
-    answer = "default answer " + wrapInQuotes(dialog.Answer)
-  }
-  if dialog.HiddenAnswer {
-    hiddenAnswer = "with hidden answer"
-  }
-  if dialog.Icon != "" {
-    if strings.Index(dialog.Icon, ".icns") > 0 {
-      // found a filepath to an icon
-      icon = "with icon " + wrapInQuotes(dialog.Icon)
-    } else {
-      // using a system icon
-      icon = "with icon " + dialog.Icon
-    }
-  }
-  if dialog.Duration > 0 {
-    duration = "giving up after " + strconv.Itoa(dialog.Duration)
-  }
-  if dialog.Buttons != "" {
-    buttons = makeButtonList(dialog.Buttons)
+	if dialog.Title != "" {
+		title = "with title " + wrapInQuotes(dialog.Title)
+	}
+	if dialog.Answer != "" {
+		answer = "default answer " + wrapInQuotes(dialog.Answer)
+	} else if dialog.Answer == "" {
+		answer = "default answer \"\""
+	}
+	if dialog.HiddenAnswer {
+		hiddenAnswer = "with hidden answer"
+	}
+	if dialog.Icon != "" {
+		if strings.Index(dialog.Icon, ".icns") > 0 {
+			// found a filepath to an icon
+			icon = "with icon " + wrapInQuotes(dialog.Icon)
+		} else {
+			// using a system icon
+			icon = "with icon " + dialog.Icon
+		}
+	}
+	if dialog.Duration > 0 {
+		duration = "giving up after " + strconv.Itoa(dialog.Duration)
+	}
+	if dialog.Buttons != "" {
+		buttons = makeButtonList(dialog.Buttons)
 
-    if dialog.DefaultButton != "" {
-      defaultButton = "default button " + wrapInQuotes(dialog.DefaultButton)
-    }
-  }
+		if dialog.DefaultButton != "" {
+			defaultButton = "default button " + wrapInQuotes(dialog.DefaultButton)
+		}
+	}
 
-  return build("display dialog", text, title, answer, hiddenAnswer, icon, duration, buttons, defaultButton)
+	return build("display dialog", text, title, answer, hiddenAnswer, icon, duration, buttons, defaultButton)
 }
 
 // DialogOptions are used to generate a DialogBox
 type DialogOptions struct {
-  Text string           // The content of the dialog box
-  Title string          // The title of the dialog box, displayed in emphasis
-  Answer string         // The default text in the input field
-  HiddenAnswer bool     // If true, converts the answer text to bullets (like a password field)
-  Icon string           // The path to a .icns file, or one of the following: "stop", "note", "caution"
-  Duration int          // The number of seconds to wait for a user response
+	Text         string // The content of the dialog box
+	Title        string // The title of the dialog box, displayed in emphasis
+	Answer       string // The default text in the input field
+	HiddenAnswer bool   // If true, converts the answer text to bullets (like a password field)
+	Icon         string // The path to a .icns file, or one of the following: "stop", "note", "caution"
+	Duration     int    // The number of seconds to wait for a user response
 
-  // Buttons
-  Buttons string        // The list of up to 3 buttons. Must be commas separated, ex. "Yes, No, Don't Know"
-  DefaultButton string  // The default selected button from the button list, ex. "Don't Know"
+	// Buttons
+	Buttons       string // The list of up to 3 buttons. Must be commas separated, ex. "Yes, No, Don't Know"
+	DefaultButton string // The default selected button from the button list, ex. "Don't Know"
 }


### PR DESCRIPTION
Support empty string defaults for the AppleScript dialog boxes.

This resolves an issue where if the `Answer` field was set as the empty string, it would no longer show the textbox. This allows a textbox-always handling for empty string answers, to ensure the textbox exists. As we don't leverage the dialog for confirmation windows, this is sufficient to handle out input case.

Confirmed working by testing locally with the AppleScript base cases (push/totp, no username, etc).

Additionally the location of the config file is now using the `projectFileName` constant.